### PR TITLE
[Chore] #14 API 에러 스펙 타입 정의 + error mapper 작성

### DIFF
--- a/src/api/errors/errorCodes.ts
+++ b/src/api/errors/errorCodes.ts
@@ -1,0 +1,37 @@
+// -------------------------------------------------------
+// 백엔드 에러/성공 코드 상수
+// @see common/.../status/ErrorStatus.java
+// @see common/.../status/SuccessStatus.java
+// -------------------------------------------------------
+
+/** 성공 코드 */
+export const SUCCESS_CODES = {
+  OK: "COMMON_200",
+  CREATED: "COMMON_201",
+  NO_CONTENT: "COMMON_204",
+} as const;
+
+/** 에러 코드 */
+export const ERROR_CODES = {
+  // 공통
+  BAD_REQUEST: "COMMON_400",
+  UNAUTHORIZED: "COMMON_401",
+  FORBIDDEN: "COMMON_403",
+  NOT_FOUND: "COMMON_404",
+  INTERNAL_SERVER_ERROR: "COMMON_500",
+
+  // 입력값 검증
+  VALIDATION_ERROR: "VALID_401",
+
+  // --------------------------------------------------
+  // TODO: 도메인별 에러 코드 추가 (백엔드 확정 후)
+  // 예시:
+  // CONCERT_NOT_FOUND: 'CONCERT_404',
+  // SEAT_ALREADY_RESERVED: 'SEAT_409',
+  // PAYMENT_FAILED: 'PAYMENT_500',
+  // --------------------------------------------------
+} as const;
+
+export type SuccessCode = (typeof SUCCESS_CODES)[keyof typeof SUCCESS_CODES];
+export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
+export type ApiCode = SuccessCode | ErrorCode;

--- a/src/api/errors/errorCodes.ts
+++ b/src/api/errors/errorCodes.ts
@@ -1,17 +1,11 @@
-// -------------------------------------------------------
-// 백엔드 에러/성공 코드 상수
-// @see common/.../status/ErrorStatus.java
-// @see common/.../status/SuccessStatus.java
-// -------------------------------------------------------
-
-/** 성공 코드 */
+// 성공 코드
 export const SUCCESS_CODES = {
   OK: "COMMON_200",
   CREATED: "COMMON_201",
   NO_CONTENT: "COMMON_204",
 } as const;
 
-/** 에러 코드 */
+// 에러 코드
 export const ERROR_CODES = {
   // 공통
   BAD_REQUEST: "COMMON_400",
@@ -25,10 +19,6 @@ export const ERROR_CODES = {
 
   // --------------------------------------------------
   // TODO: 도메인별 에러 코드 추가 (백엔드 확정 후)
-  // 예시:
-  // CONCERT_NOT_FOUND: 'CONCERT_404',
-  // SEAT_ALREADY_RESERVED: 'SEAT_409',
-  // PAYMENT_FAILED: 'PAYMENT_500',
   // --------------------------------------------------
 } as const;
 

--- a/src/api/errors/errorMapper.ts
+++ b/src/api/errors/errorMapper.ts
@@ -2,8 +2,7 @@
 // errorMapper: 백엔드 에러 코드 → 프론트 UI 메시지 변환
 //
 // 역할: 백엔드 스펙 변경으로부터 프론트 UI를 보호하는 안정 레이어
-// - 백엔드 message를 기본값으로 활용하되,
-//   프론트에서 재정의가 필요한 경우 여기서 오버라이드
+// - 백엔드 message를 기본값으로 활용하되 프론트에서 재정의가 필요한 경우 여기서 오버라이드
 // -------------------------------------------------------
 
 import { ERROR_CODES, type ErrorCode } from "./errorCodes";
@@ -40,7 +39,6 @@ const ERROR_MESSAGE_OVERRIDES: Partial<Record<ErrorCode, string>> = {
   // [ERROR_CODES.FORBIDDEN]: '접근 권한이 없습니다.',
 };
 
-/** 알 수 없는 에러 코드일 때 사용할 기본 메시지 */
 const FALLBACK_MESSAGE =
   "알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
 
@@ -48,14 +46,11 @@ const FALLBACK_MESSAGE =
 // 매핑 함수
 // -------------------------------------------------------
 
-/**
- * 에러 코드와 백엔드 메시지를 받아 UI에 표시할 최종 메시지를 반환
- *
- * 우선순위:
- * 1. ERROR_MESSAGE_OVERRIDES에 정의된 프론트 오버라이드 메시지
- * 2. 백엔드에서 내려준 message
- * 3. FALLBACK_MESSAGE
- */
+// 우선순위:
+// 1. ERROR_MESSAGE_OVERRIDES에 정의된 프론트 오버라이드 메시지
+// 2. 백엔드에서 내려준 message
+// 3. FALLBACK_MESSAGE
+//
 export function mapErrorToMessage(
   code: string,
   backendMessage?: string,

--- a/src/api/errors/errorMapper.ts
+++ b/src/api/errors/errorMapper.ts
@@ -1,0 +1,85 @@
+// -------------------------------------------------------
+// errorMapper: 백엔드 에러 코드 → 프론트 UI 메시지 변환
+//
+// 역할: 백엔드 스펙 변경으로부터 프론트 UI를 보호하는 안정 레이어
+// - 백엔드 message를 기본값으로 활용하되,
+//   프론트에서 재정의가 필요한 경우 여기서 오버라이드
+// -------------------------------------------------------
+
+import { ERROR_CODES, type ErrorCode } from "./errorCodes";
+import type { ApiErrorResponse } from "../types/response";
+
+// -------------------------------------------------------
+// 커스텀 에러 클래스
+// -------------------------------------------------------
+
+export class ApiError extends Error {
+  public readonly code: string;
+  public readonly httpStatus?: number;
+
+  constructor(response: ApiErrorResponse, httpStatus?: number) {
+    const uiMessage = mapErrorToMessage(response.code, response.message);
+    super(uiMessage);
+
+    this.name = "ApiError";
+    this.code = response.code;
+    this.httpStatus = httpStatus;
+  }
+}
+
+// -------------------------------------------------------
+// 에러 코드 → UI 메시지 매핑 테이블
+//
+// - null 이면 백엔드 message를 그대로 사용
+// - 문자열이면 프론트에서 오버라이드
+// -------------------------------------------------------
+
+const ERROR_MESSAGE_OVERRIDES: Partial<Record<ErrorCode, string>> = {
+  // 예시: 백엔드 메시지 대신 프론트 자체 문구를 쓰고 싶을 때
+  // [ERROR_CODES.UNAUTHORIZED]: '로그인이 필요합니다. 다시 로그인해주세요.',
+  // [ERROR_CODES.FORBIDDEN]: '접근 권한이 없습니다.',
+};
+
+/** 알 수 없는 에러 코드일 때 사용할 기본 메시지 */
+const FALLBACK_MESSAGE =
+  "알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+
+// -------------------------------------------------------
+// 매핑 함수
+// -------------------------------------------------------
+
+/**
+ * 에러 코드와 백엔드 메시지를 받아 UI에 표시할 최종 메시지를 반환
+ *
+ * 우선순위:
+ * 1. ERROR_MESSAGE_OVERRIDES에 정의된 프론트 오버라이드 메시지
+ * 2. 백엔드에서 내려준 message
+ * 3. FALLBACK_MESSAGE
+ */
+export function mapErrorToMessage(
+  code: string,
+  backendMessage?: string,
+): string {
+  const override = ERROR_MESSAGE_OVERRIDES[code as ErrorCode];
+  if (override) return override;
+  if (backendMessage) return backendMessage;
+  return FALLBACK_MESSAGE;
+}
+
+// -------------------------------------------------------
+// 유틸: 특정 에러 코드인지 확인
+// -------------------------------------------------------
+
+export function isUnauthorizedError(error: unknown): boolean {
+  return error instanceof ApiError && error.code === ERROR_CODES.UNAUTHORIZED;
+}
+
+export function isForbiddenError(error: unknown): boolean {
+  return error instanceof ApiError && error.code === ERROR_CODES.FORBIDDEN;
+}
+
+export function isValidationError(error: unknown): boolean {
+  return (
+    error instanceof ApiError && error.code === ERROR_CODES.VALIDATION_ERROR
+  );
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,22 @@
+// api/index.ts — 배럴 export
+export { default as apiClient } from "./instance";
+export { queryClient } from "./queryClient";
+
+// 타입
+export type {
+  ApiResponse,
+  ApiSuccessResponse,
+  ApiErrorResponse,
+} from "./types/response";
+export { isApiError, isApiSuccess } from "./types/response";
+
+// 에러
+export { ERROR_CODES, SUCCESS_CODES } from "./errors/errorCodes";
+export type { ErrorCode, SuccessCode, ApiCode } from "./errors/errorCodes";
+export {
+  ApiError,
+  mapErrorToMessage,
+  isUnauthorizedError,
+  isForbiddenError,
+  isValidationError,
+} from "./errors/errorMapper";

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -1,0 +1,86 @@
+// -------------------------------------------------------
+// Axios 인스턴스 + Response Interceptor
+//
+// 역할 (데이터 레이어):
+// - 응답에서 isSuccess 체크
+// - 실패 시 ApiError로 변환하여 throw
+// - 성공 시 result만 추출하여 반환
+//
+// UI 처리(토스트 등)는 여기서 하지 않음 → queryClient.ts에서 담당
+// -------------------------------------------------------
+
+import axios from "axios";
+import type { ApiResponse } from "./types/response";
+import { isApiError } from "./types/response";
+import { ApiError } from "./errors/errorMapper";
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080",
+  timeout: 10_000,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+// -------------------------------------------------------
+// Response Interceptor
+// -------------------------------------------------------
+
+apiClient.interceptors.response.use(
+  (response) => {
+    const data = response.data as ApiResponse;
+
+    // 백엔드가 isSuccess: false로 내려준 경우 → 에러로 전환
+    if (isApiError(data)) {
+      throw new ApiError(data, response.status);
+    }
+
+    // 성공 시 result만 꺼내서 반환 (unwrap)
+    // → useQuery에서 data가 바로 result 타입이 됨
+    return data.result;
+  },
+  (error) => {
+    // 네트워크 에러, 타임아웃 등 HTTP 응답 자체가 없는 경우
+    if (axios.isAxiosError(error) && error.response) {
+      const data = error.response.data as ApiResponse;
+
+      // 백엔드 에러 응답 포맷이면 ApiError로 변환
+      if (data && typeof data.isSuccess === "boolean") {
+        throw new ApiError(
+          {
+            isSuccess: false,
+            code: data.code,
+            message: data.message,
+            result: null,
+          },
+          error.response.status,
+        );
+      }
+    }
+
+    // 그 외 예상치 못한 에러
+    throw new ApiError(
+      {
+        isSuccess: false,
+        code: "UNKNOWN",
+        message: "네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.",
+        result: null,
+      },
+      0,
+    );
+  },
+);
+
+// -------------------------------------------------------
+// Request Interceptor (토큰 주입용 — 인증 이슈에서 확장)
+// -------------------------------------------------------
+
+// apiClient.interceptors.request.use((config) => {
+//   const token = useAuthStore.getState().accessToken;
+//   if (token) {
+//     config.headers.Authorization = `Bearer ${token}`;
+//   }
+//   return config;
+// });
+
+export default apiClient;

--- a/src/api/queryClient.ts
+++ b/src/api/queryClient.ts
@@ -1,0 +1,70 @@
+// -------------------------------------------------------
+// QueryClient 설정 + 글로벌 에러 핸들링
+//
+// 역할 (UI 레이어):
+// - ApiError를 받아서 토스트로 사용자에게 알림
+// - 401 에러 시 로그인 페이지 리다이렉트 등 공통 처리
+//
+// 에러 파싱/throw는 instance.ts interceptor가 담당
+// -------------------------------------------------------
+
+import { QueryClient, QueryCache, MutationCache } from "@tanstack/react-query";
+import { ApiError, isUnauthorizedError } from "./errors/errorMapper";
+
+// -------------------------------------------------------
+// TODO: 프로젝트에서 사용하는 toast 라이브러리로 교체
+// 예시: import { toast } from 'react-hot-toast';
+//       import { toast } from 'sonner';
+// -------------------------------------------------------
+const toast = {
+  error: (message: string) => {
+    console.error("[Toast]", message); // 임시 — toast 라이브러리 연동 후 교체
+  },
+};
+
+// -------------------------------------------------------
+// 공통 에러 핸들러
+// -------------------------------------------------------
+
+function handleGlobalError(error: unknown) {
+  if (!(error instanceof ApiError)) {
+    toast.error("알 수 없는 오류가 발생했습니다.");
+    return;
+  }
+
+  // 401 → 로그인 페이지로 리다이렉트
+  if (isUnauthorizedError(error)) {
+    // TODO: 인증 이슈에서 구현
+    // useAuthStore.getState().logout();
+    // window.location.href = '/login';
+    toast.error("로그인이 만료되었습니다. 다시 로그인해주세요.");
+    return;
+  }
+
+  // 그 외 → ApiError.message (errorMapper가 이미 변환한 UI 메시지)
+  toast.error(error.message);
+}
+
+// -------------------------------------------------------
+// QueryClient 생성
+// -------------------------------------------------------
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 2,
+      retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+      staleTime: 1000 * 60 * 5,
+      refetchOnWindowFocus: false,
+    },
+    mutations: {
+      retry: 0,
+    },
+  },
+  queryCache: new QueryCache({
+    onError: handleGlobalError,
+  }),
+  mutationCache: new MutationCache({
+    onError: handleGlobalError,
+  }),
+});

--- a/src/api/queryClient.ts
+++ b/src/api/queryClient.ts
@@ -13,8 +13,6 @@ import { ApiError, isUnauthorizedError } from "./errors/errorMapper";
 
 // -------------------------------------------------------
 // TODO: 프로젝트에서 사용하는 toast 라이브러리로 교체
-// 예시: import { toast } from 'react-hot-toast';
-//       import { toast } from 'sonner';
 // -------------------------------------------------------
 const toast = {
   error: (message: string) => {

--- a/src/api/types/response.ts
+++ b/src/api/types/response.ts
@@ -1,9 +1,9 @@
 //  백엔드 공통 응답 포맷 (성공 + 실패 모두 동일 구조)
 export interface ApiResponse<T = unknown> {
   isSuccess: boolean;
-  code: string; // e.g. "COMMON_200", "COMMON_401", "VALID_401"
-  message: string; // 백엔드에서 내려주는 한국어 메시지
-  result: T | null; // 성공 시 데이터, 실패 시 null 또는 에러 상세
+  code: string;
+  message: string;
+  result: T | null;
 }
 
 // 성공 응답 — isSuccess: true 가 보장된 타입

--- a/src/api/types/response.ts
+++ b/src/api/types/response.ts
@@ -1,0 +1,33 @@
+//  백엔드 공통 응답 포맷 (성공 + 실패 모두 동일 구조)
+export interface ApiResponse<T = unknown> {
+  isSuccess: boolean;
+  code: string; // e.g. "COMMON_200", "COMMON_401", "VALID_401"
+  message: string; // 백엔드에서 내려주는 한국어 메시지
+  result: T | null; // 성공 시 데이터, 실패 시 null 또는 에러 상세
+}
+
+// 성공 응답 — isSuccess: true 가 보장된 타입
+export interface ApiSuccessResponse<T> extends ApiResponse<T> {
+  isSuccess: true;
+  result: T;
+}
+
+// 실패 응답 — isSuccess: false 가 보장된 타입
+export interface ApiErrorResponse extends ApiResponse<null> {
+  isSuccess: false;
+  result: null;
+}
+
+// -------------------------------------------------------
+// 타입 가드
+// -------------------------------------------------------
+
+export function isApiError(res: ApiResponse): res is ApiErrorResponse {
+  return !res.isSuccess;
+}
+
+export function isApiSuccess<T>(
+  res: ApiResponse<T>,
+): res is ApiSuccessResponse<T> {
+  return res.isSuccess;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #14

---

## 📌 주요 변경 사항

- 백엔드 ApiResponse 포맷 기반 공통 응답 타입 체계 구축
- Axios 응답 인터셉터에서 에러 자동 변환 (ApiError)
- QueryClient 글로벌 에러 핸들링 설정

 ***

## 🛠 상세 구현 내용

### 파일 구조

> src/api/
├── index.ts           — 배럴 export
├── instance.ts        — Axios 인스턴스 + Response Interceptor
├── queryClient.ts     — QueryClient + 글로벌 에러 핸들링
├── types/
│   └── response.ts    — ApiResponse 공통 응답 타입
└── errors/
├── errorCodes.ts  — 에러/성공 코드 상수
└── errorMapper.ts — ApiError 클래스 + 에러 메시지 매핑

### 주요 설계
- **역할 분리**: instance.ts(데이터 레이어) vs queryClient.ts(UI 레이어)
  - instance.ts: 응답에서 isSuccess 체크 → 실패 시 ApiError throw, 성공 시 result unwrap
  - queryClient.ts: ApiError를 받아 toast로 사용자에게 알림
- **에러 매핑 우선순위**: 프론트 오버라이드 → 백엔드 message → fallback 메시지
- **QueryClient 설정**: queries retry: 2 (exponential backoff) / mutations retry: 0

### 참고
- Request Interceptor(토큰 주입)는 #22에서 활성화 예정
- toast는 현재 console 출력, #17 후 교체 예정
- 도메인별 에러 코드는 백엔드 API 확정 후 추가 예정

***

## 👀 리뷰 요청 사항

- errorMapper 매핑 구조가 백엔드 에러 포맷과 잘 맞는지 확인 부탁드립니다
- QueryClient retry/staleTime 설정값이 적절한지 의견 부탁드립니다
***
