### PR TITLE
[Feat] #20 회원가입 페이지 구현

### DIFF
--- a/src/pages/Auth/SignupPage.tsx
+++ b/src/pages/Auth/SignupPage.tsx
@@ -1,0 +1,165 @@
+import { Link, useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { signupSchema, type SignupFormData } from "../../schemas/auth";
+// import { apiClient } from '../../api';
+import Button from "../../components/common/Button/Button";
+import Input from "../../components/common/Input/Input";
+
+// TODO: 백엔드 완성 시 apiClient.post로 교체
+const mockRegister = async (data: SignupFormData) => {
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  if (data.email === "exist@test.com") {
+    throw { response: { status: 409 } };
+  }
+  return { message: "success" };
+};
+
+export default function SignupPage() {
+  const navigate = useNavigate();
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm<SignupFormData>({
+    resolver: zodResolver(signupSchema),
+  });
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: mockRegister, // TODO: (data) => apiClient.post('/api/auth/register', data)
+    onSuccess: () => {
+      // TODO: toast.success('회원가입이 완료되었습니다')
+      console.log("signup success");
+      navigate("/login");
+    },
+    onError: (error: unknown) => {
+      const err = error as { response?: { status?: number } };
+      if (err?.response?.status === 409) {
+        setError("email", { message: "이미 사용 중인 이메일입니다" });
+      }
+      // status >= 500 은 QueryClient onError에서 toast.error 처리
+    },
+  });
+
+  const onSubmit = (data: SignupFormData) => {
+    mutate(data);
+  };
+
+  return (
+    <div className="relative flex justify-center min-h-screen px-6 pt-20 pb-10 bg-[#f8f9fa]">
+      {/* 뒤로가기 */}
+      <div className="absolute top-6 left-6">
+        <Button variant="secondary" size="sm" onClick={() => navigate(-1)}>
+          ← 뒤로가기
+        </Button>
+      </div>
+
+      {/* 카드 */}
+      <div className="w-full max-w-[480px] px-10 py-12 bg-white rounded-2xl border border-border self-start">
+        <h1 className="font-pretendard text-[28px] font-bold text-text mb-2">
+          회원가입
+        </h1>
+        <p className="font-pretendard text-base text-text-secondary mb-8">
+          새 계정을 만드세요
+        </p>
+
+        {/* 폼 */}
+        <form
+          className="flex flex-col gap-5"
+          onSubmit={handleSubmit(onSubmit)}
+          noValidate
+        >
+          <Input
+            label="이름"
+            icon={<span>👤</span>}
+            required
+            type="text"
+            placeholder="이름을 입력해주세요"
+            error={errors.name?.message}
+            {...register("name")}
+          />
+          <Input
+            label="이메일"
+            icon={<span>✉</span>}
+            required
+            type="email"
+            placeholder="user@example.com"
+            error={errors.email?.message}
+            {...register("email")}
+          />
+          <Input
+            label="인증 번호"
+            icon={<span>⊙</span>}
+            required
+            type="text"
+            placeholder="xxxxxx"
+            error={errors.verificationCode?.message}
+            helperText="이메일로 발송된 인증 번호를 입력해주세요"
+            {...register("verificationCode")}
+          />
+          <Input
+            label="비밀번호"
+            icon={<span>🔒</span>}
+            required
+            type="password"
+            placeholder="비밀번호를 입력해주세요 (8자 이상)"
+            error={errors.password?.message}
+            {...register("password")}
+          />
+          <Input
+            label="비밀번호 확인"
+            icon={<span>🔒</span>}
+            required
+            type="password"
+            placeholder="비밀번호를 다시 입력해주세요"
+            error={errors.passwordConfirm?.message}
+            {...register("passwordConfirm")}
+          />
+
+          <Button
+            type="submit"
+            variant="primary"
+            size="lg"
+            fullWidth
+            loading={isPending}
+          >
+            회원가입
+          </Button>
+        </form>
+
+        {/* 구분선 */}
+        <div className="flex items-center gap-4 my-7">
+          <div className="flex-1 h-px bg-border" />
+          <span className="font-pretendard text-sm text-text-secondary whitespace-nowrap">
+            간편 로그인
+          </span>
+          <div className="flex-1 h-px bg-border" />
+        </div>
+
+        {/* OAuth */}
+        <div className="flex gap-3">
+          <Button variant="kakao" size="md" className="flex-1">
+            카카오
+          </Button>
+          <Button variant="naver" size="md" className="flex-1">
+            네이버
+          </Button>
+          <Button variant="google" size="md" className="flex-1">
+            구글
+          </Button>
+        </div>
+
+        {/* 푸터 */}
+        <p className="font-pretendard text-sm text-text-secondary text-center mt-6">
+          이미 계정이 있으신가요?{" "}
+          <Link to="/login" className="text-primary font-semibold underline">
+            로그인
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, "이메일을 입력해주세요")
+    .email("올바른 이메일을 입력해주세요"),
+  password: z.string().min(1, "비밀번호를 입력해주세요"),
+});
+
+export type LoginFormData = z.infer<typeof loginSchema>;
+
+export const signupSchema = z
+  .object({
+    name: z.string().min(1, "이름을 입력해주세요"),
+    email: z
+      .string()
+      .min(1, "이메일을 입력해주세요")
+      .email("올바른 이메일을 입력해주세요"),
+    verificationCode: z.string().min(1, "인증 번호를 입력해주세요"),
+    password: z.string().min(8, "비밀번호는 8자 이상이어야 합니다"),
+    passwordConfirm: z.string().min(1, "비밀번호 확인을 입력해주세요"),
+  })
+  .refine((data) => data.password === data.passwordConfirm, {
+    message: "비밀번호가 일치하지 않습니다",
+    path: ["passwordConfirm"],
+  });
+
+export type SignupFormData = z.infer<typeof signupSchema>;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #20

---

## 📌 주요 변경 사항

- 회원가입 페이지 구현

***

## 🛠 상세 구현 내용

- react-hook-form + zod + @hookform/resolvers 설치
- 회원가입 폼 (이름, 이메일, 인증번호, 비밀번호, 확인)
- 유효성 검증 (이메일 형식, 인증번호 필수, 비번 8자, 일치 확인)
- useMutation + Mock mutationFn → 백엔드 완성 시 mutationFn만 교체
 ***

## ✅ 테스트

### 테스트 방법

- `$ npm run dev` 입력 후 /signup 페이지 확인

### 테스트 결과

- (Merge 후 추가 예정)

### 📸 스크린샷

- (Merge 후 추가 예정)
---

## 👀 리뷰 요청 사항

- 다른 PR 선승인 후 확인 필요합니다.

 ***
