### PR TITLE
[Feat] #16, 17, 18 공통 UI 컴포넌트 (Modal, Toast, Badge, Skeleton) 구현

### DIFF
--- a/src/api/queryClient.ts
+++ b/src/api/queryClient.ts
@@ -2,7 +2,7 @@
 // QueryClient 설정 + 글로벌 에러 핸들링
 //
 // 역할 (UI 레이어):
-// - ApiError를 받아서 토스트로 사용자에게 알림
+// - ApiError를 받아서 toast로 사용자에게 알림
 // - 401 에러 시 로그인 페이지 리다이렉트 등 공통 처리
 //
 // 에러 파싱/throw는 instance.ts interceptor가 담당
@@ -10,15 +10,7 @@
 
 import { QueryClient, QueryCache, MutationCache } from "@tanstack/react-query";
 import { ApiError, isUnauthorizedError } from "./errors/errorMapper";
-
-// -------------------------------------------------------
-// TODO: 프로젝트에서 사용하는 toast 라이브러리로 교체
-// -------------------------------------------------------
-const toast = {
-  error: (message: string) => {
-    console.error("[Toast]", message); // 임시 — toast 라이브러리 연동 후 교체
-  },
-};
+import { toast } from "../utils/toast";
 
 // -------------------------------------------------------
 // 공통 에러 핸들러
@@ -32,7 +24,7 @@ function handleGlobalError(error: unknown) {
 
   // 401 → 로그인 페이지로 리다이렉트
   if (isUnauthorizedError(error)) {
-    // TODO: 인증 이슈에서 구현
+    // TODO: Feat #8 완료 후 활성화
     // useAuthStore.getState().logout();
     // window.location.href = '/login';
     toast.error("로그인이 만료되었습니다. 다시 로그인해주세요.");

--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -1,0 +1,62 @@
+// components/common/Badge/Badge.tsx
+import { type ReactNode } from "react";
+
+export type BadgeStatus =
+  | "예매완료"
+  | "결제중"
+  | "취소"
+  | "환불"
+  | "예매불가"
+  | "예매가능";
+
+export type BadgeSize = "sm" | "md";
+
+export interface BadgeProps {
+  status: BadgeStatus;
+  size?: BadgeSize;
+  /** status 자동 텍스트를 다른 텍스트로 오버라이드 (선택) */
+  children?: ReactNode;
+  /** Tailwind 클래스로 직접 색상/스타일 오버라이드 */
+  className?: string;
+}
+
+// status별 라벨 + 색상 매핑
+const statusConfig: Record<BadgeStatus, { label: string; style: string }> = {
+  예매완료: { label: "예매완료", style: "bg-success/15 text-success" },
+  결제중: { label: "결제중", style: "bg-primary/15 text-primary" },
+  취소: { label: "취소", style: "bg-danger/15 text-danger" },
+  환불: { label: "환불", style: "bg-orange-100 text-orange-600" },
+  예매불가: { label: "매진", style: "bg-gray-200 text-gray-600" },
+  예매가능: { label: "예매가능", style: "bg-teal/15 text-teal" },
+};
+
+const sizeStyles: Record<BadgeSize, string> = {
+  sm: "px-2 py-0.5 text-xs",
+  md: "px-2.5 py-1 text-sm",
+};
+
+export default function Badge({
+  status,
+  size = "md",
+  children,
+  className = "",
+}: BadgeProps) {
+  const config = statusConfig[status];
+
+  return (
+    <span
+      className={[
+        "inline-flex items-center gap-1",
+        "font-pretendard font-semibold rounded-full whitespace-nowrap",
+        config.style,
+        sizeStyles[size],
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {/* children이 있으면 우선, 없으면 status 기본 라벨 */}
+      {children ?? config.label}
+    </span>
+  );
+}

--- a/src/components/common/CircularTimer/CircularTimer.tsx
+++ b/src/components/common/CircularTimer/CircularTimer.tsx
@@ -1,0 +1,135 @@
+// src/components/common/CircularTimer/CircularTimer.tsx
+import { useMemo } from "react";
+
+interface CircularTimerProps {
+  /** 남은 시간 (초) */
+  remainingSeconds: number;
+  /** 전체 시간 (초) — 기본 300초(5분) */
+  totalSeconds?: number;
+  /** SVG 크기 (px) — 기본 280 */
+  size?: number;
+  /** 호 두께 (px) — 기본 18 */
+  strokeWidth?: number;
+}
+
+/**
+ * 좌석 임시 예약 카운트다운 타이머 (4개 호 디자인)
+ *
+ * ─ 운영 정책 ────────────────────────────────────────
+ * [카운트다운 및 프로그레스 바 로직]
+ *  - 프로그레스 바 동기화: 남은 시간에 비례하여 원형 프로그레스가 줄어듦
+ *  - 1분 미만: 빨간색(#C10007) 변경
+ *
+ * [디자인 가이드]
+ *  - 원형 프로그레스: 보라색(#6C5CE7), SVG 기반
+ *  - 카운트다운 텍스트: 큰 폰트, 1분 미만 시 빨간색
+ *  - "남은 시간" 텍스트 하단 배치
+ * ────────────────────────────────────────────────────
+ *
+ * ─ 디자인 ──────────────────────────────────────────
+ * 원이 4개의 호로 분할된 형태 (12·3·6·9시 방향에 호 중심).
+ * 진행률에 따라 보라색 호가 시계 방향으로 줄어들면서
+ * 뒤의 회색 호가 드러나는 구조.
+ * ────────────────────────────────────────────────────
+ *
+ * @example
+ * <CircularTimer remainingSeconds={298} />
+ *
+ * timerStore의 remainingMs와 함께 사용:
+ * const remainingMs = useTimerStore(s => s.remainingMs);
+ * <CircularTimer remainingSeconds={Math.ceil(remainingMs / 1000)} />
+ */
+export function CircularTimer({
+  remainingSeconds,
+  totalSeconds = 300,
+  size = 280,
+  strokeWidth = 18,
+}: CircularTimerProps) {
+  // 0 이하 또는 totalSeconds 초과 방어
+  const clampedRemaining = Math.max(
+    0,
+    Math.min(remainingSeconds, totalSeconds),
+  );
+
+  // SVG 기하 계산 (useMemo로 size/strokeWidth 변경 시에만 재계산)
+  const geometry = useMemo(() => {
+    const radius = (size - strokeWidth) / 2;
+    const circumference = 2 * Math.PI * radius;
+
+    // 4개 호로 분할: 호:갭 = 7:3
+    const SEGMENTS = 4;
+    const ARC_RATIO = 0.7;
+    const segmentLength = circumference / SEGMENTS;
+    const arcLength = segmentLength * ARC_RATIO;
+    const gapLength = segmentLength - arcLength;
+
+    return { radius, circumference, arcLength, gapLength };
+  }, [size, strokeWidth]);
+
+  // 진행률 — 남은 시간에 비례 (운영 정책: "타이머의 남은 시간과 비례")
+  const progress = clampedRemaining / totalSeconds;
+  const dashOffset = geometry.circumference * (1 - progress);
+
+  // 운영 정책: 1분 미만 빨간색 변경
+  const isWarning = clampedRemaining < 60;
+  const progressColor = isWarning ? "#C10007" : "#6C5CE7";
+
+  // 시간 포맷팅 (M:SS)
+  const minutes = Math.floor(clampedRemaining / 60);
+  const seconds = clampedRemaining % 60;
+  const timeText = `${minutes}:${seconds.toString().padStart(2, "0")}`;
+
+  const center = size / 2;
+  const dashArray = `${geometry.arcLength} ${geometry.gapLength}`;
+
+  return (
+    <div className="relative inline-flex flex-col items-center justify-center">
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        role="img"
+        aria-label={`남은 시간 ${minutes}분 ${seconds}초`}
+      >
+        {/* 배경 — 회색 4개 호 (항상 표시) */}
+        <circle
+          cx={center}
+          cy={center}
+          r={geometry.radius}
+          fill="none"
+          stroke="#E5E7EB"
+          strokeWidth={strokeWidth}
+          strokeDasharray={dashArray}
+          strokeLinecap="round"
+          transform={`rotate(-90 ${center} ${center})`}
+        />
+        {/* 진행 — 보라색 호 (시간 지나면서 줄어듦) */}
+        <circle
+          cx={center}
+          cy={center}
+          r={geometry.radius}
+          fill="none"
+          stroke={progressColor}
+          strokeWidth={strokeWidth}
+          strokeDasharray={dashArray}
+          strokeDashoffset={dashOffset}
+          strokeLinecap="round"
+          transform={`rotate(-90 ${center} ${center})`}
+          className="transition-[stroke-dashoffset,stroke] duration-1000 ease-linear"
+        />
+      </svg>
+
+      {/* 중앙 텍스트 — SVG 위에 absolute 배치 */}
+      <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+        <span
+          className={`text-5xl font-bold tabular-nums leading-none ${
+            isWarning ? "text-[#C10007]" : "text-primary"
+          }`}
+        >
+          {timeText}
+        </span>
+        <span className="mt-3 text-sm text-gray-500">남은 시간</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -1,0 +1,134 @@
+// components/common/Modal/Modal.tsx
+import { type ReactNode, useEffect, useId } from "react";
+import { createPortal } from "react-dom";
+import type FocusTrap from "focus-trap-react";
+import { X } from "lucide-react";
+
+export type ModalSize = "sm" | "md" | "lg";
+
+export interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  /** sm: 작은 확인 모달 / md: 일반(기본) / lg: 폼이 들어가는 큰 모달 */
+  size?: ModalSize;
+  /** 오버레이 클릭으로 닫기 비활성화 (예: 결제 진행 중) */
+  disableOverlayClose?: boolean;
+  /** ESC로 닫기 비활성화 */
+  disableEscClose?: boolean;
+}
+
+const sizeStyles: Record<ModalSize, string> = {
+  sm: "max-w-sm", // 384px — 단순 확인/경고
+  md: "max-w-md", // 448px — 기본
+  lg: "max-w-lg", // 512px — 폼 포함
+};
+
+export default function Modal({
+  isOpen,
+  onClose,
+  title,
+  children,
+  footer,
+  size = "md",
+  disableOverlayClose = false,
+  disableEscClose = false,
+}: ModalProps) {
+  // 제목과 aria-labelledby를 연결할 고유 ID
+  const titleId = useId();
+
+  // ESC 키로 닫기
+  useEffect(() => {
+    if (!isOpen || disableEscClose) return;
+
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, [isOpen, onClose, disableEscClose]);
+
+  // 배경 스크롤 방지
+  // ⚠️ 단일 모달 기준으로 동작.
+  //    nested modal이 필요해지면 body-scroll-lock 같은 라이브러리 도입 검토.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (disableOverlayClose) return;
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+      onClick={handleOverlayClick}
+    >
+      <FocusTrap
+        focusTrapOptions={{
+          // 모달 닫힐 때 원래 포커스 위치로 복귀
+          returnFocusOnDeactivate: true,
+          // 모달 안에 포커스 가능한 요소가 없을 때의 fallback
+          fallbackFocus: '[role="dialog"]',
+        }}
+      >
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={title ? titleId : undefined}
+          tabIndex={-1}
+          className={[
+            "w-full bg-white rounded-2xl shadow-xl overflow-hidden outline-none",
+            sizeStyles[size],
+          ].join(" ")}
+        >
+          {/* 헤더 */}
+          {title && (
+            <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+              <h2
+                id={titleId}
+                className="font-pretendard text-lg font-bold text-text"
+              >
+                {title}
+              </h2>
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-text-secondary hover:text-text transition-colors"
+                aria-label="닫기"
+              >
+                <X size={20} />
+              </button>
+            </div>
+          )}
+
+          {/* 본문 */}
+          <div className="px-6 py-5 font-pretendard text-base text-text">
+            {children}
+          </div>
+
+          {/* 푸터 */}
+          {footer && (
+            <div className="px-6 py-4 border-t border-border bg-secondary flex justify-end gap-2">
+              {footer}
+            </div>
+          )}
+        </div>
+      </FocusTrap>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/common/Skeleton/Skeleton.tsx
+++ b/src/components/common/Skeleton/Skeleton.tsx
@@ -1,0 +1,49 @@
+// components/common/Skeleton/Skeleton.tsx
+import { type CSSProperties } from "react";
+
+type Variant = "text" | "image" | "circle";
+
+export interface SkeletonProps {
+  /** text: 텍스트 줄 / image: 이미지 영역 / circle: 원형 (아바타) */
+  variant?: Variant;
+  width?: string | number;
+  height?: string | number;
+  className?: string;
+}
+const variantStyles: Record<Variant, string> = {
+  text: "rounded",
+  image: "rounded-lg",
+  circle: "rounded-full",
+};
+
+export default function Skeleton({
+  variant = "text",
+  width,
+  height,
+  className = "",
+}: SkeletonProps) {
+  const computedWidth = width ?? (variant === "circle" ? "40px" : undefined);
+
+  const computedHeight =
+    height ??
+    (variant === "text" ? "1.5rem" : variant === "circle" ? "40px" : undefined);
+
+  const style: CSSProperties = {
+    ...(computedWidth !== undefined && { width: computedWidth }),
+    ...(computedHeight !== undefined && { height: computedHeight }),
+  };
+
+  return (
+    <div
+      aria-hidden="true"
+      className={[
+        "bg-gray-200 animate-pulse",
+        variantStyles[variant],
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      style={style}
+    />
+  );
+}

--- a/src/stores/reservation/timerStore.ts
+++ b/src/stores/reservation/timerStore.ts
@@ -1,0 +1,114 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { useEffect } from "react";
+
+type TimerStatus = "idle" | "running" | "expired";
+
+interface TimerState {
+  status: TimerStatus;
+  remainingMs: number;
+  durationMs: number;
+
+  /** 타이머 시작 (default 5분) */
+  startTimer: (durationMs?: number) => void;
+  /** 타이머 정지 (정상 종료 — 결제 성공 시) */
+  stopTimer: () => void;
+  /** 모든 상태 초기화 */
+  reset: () => void;
+}
+
+const DEFAULT_DURATION_MS = 5 * 60 * 1000;
+
+// 모듈 스코프 — store 외부에 interval ID 보관 (state에 넣으면 비교 리렌더 발생)
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+function clearTimerInterval() {
+  if (intervalId !== null) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+export const useTimerStore = create<TimerState>()(
+  devtools(
+    (set) => ({
+      status: "idle",
+      remainingMs: 0,
+      durationMs: DEFAULT_DURATION_MS,
+
+      startTimer: (durationMs = DEFAULT_DURATION_MS) => {
+        clearTimerInterval();
+        const endsAt = Date.now() + durationMs;
+
+        set({ status: "running", durationMs, remainingMs: durationMs });
+
+        // 250ms 간격으로 갱신 — CircularTimer가 부드럽게 줄어들도록
+        intervalId = setInterval(() => {
+          const remaining = Math.max(0, endsAt - Date.now());
+
+          if (remaining <= 0) {
+            clearTimerInterval();
+            set({ status: "expired", remainingMs: 0 });
+          } else {
+            set({ remainingMs: remaining });
+          }
+        }, 250);
+      },
+
+      stopTimer: () => {
+        clearTimerInterval();
+        set({ status: "idle", remainingMs: 0 });
+      },
+
+      reset: () => {
+        clearTimerInterval();
+        set({
+          status: "idle",
+          remainingMs: 0,
+          durationMs: DEFAULT_DURATION_MS,
+        });
+      },
+    }),
+    { name: "TimerStore" },
+  ),
+);
+
+// ─────────────────────────────────────────────────────────
+// Convenience hooks
+// ─────────────────────────────────────────────────────────
+
+/**
+ * 타이머가 expired 상태로 전이되는 순간을 감지하여 콜백 실행.
+ * - status가 'expired'로 바뀌는 순간 한 번만 호출됨
+ * - 콜백 안에서 reset() 호출하면 다음 진입 시 중복 실행 방지
+ *
+ * @example
+ *   useTimerExpiry(() => {
+ *     paymentStore.expire();
+ *     navigate("/payment/expired");
+ *   });
+ */
+export function useTimerExpiry(onExpire: () => void) {
+  const status = useTimerStore((s) => s.status);
+  useEffect(() => {
+    if (status === "expired") onExpire();
+    // onExpire는 매 렌더마다 새 함수일 수 있어 의존성에서 제외 (필요 시 useCallback)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status]);
+}
+
+/** 남은 시간을 mm:ss 포맷으로 (CircularTimer 등에서 사용) */
+export function useTimerDisplay() {
+  const remainingMs = useTimerStore((s) => s.remainingMs);
+  const durationMs = useTimerStore((s) => s.durationMs);
+
+  const totalSec = Math.ceil(remainingMs / 1000);
+  const mm = Math.floor(totalSec / 60);
+  const ss = totalSec % 60;
+  const formatted = `${String(mm).padStart(2, "0")}:${String(ss).padStart(2, "0")}`;
+  const progress = durationMs > 0 ? remainingMs / durationMs : 0;
+
+  return { mm, ss, formatted, remainingMs, progress };
+}
+
+export default useTimerStore;

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,0 +1,24 @@
+import { toast as toastify, type ToastOptions } from "react-toastify";
+
+const defaultOptions: ToastOptions = {
+  position: "bottom-right",
+  autoClose: 3000,
+  hideProgressBar: false,
+  closeOnClick: true,
+  pauseOnHover: true,
+  draggable: true,
+};
+
+export const toast = {
+  success: (message: string, options?: ToastOptions) =>
+    toastify.success(message, { ...defaultOptions, ...options }),
+
+  error: (message: string, options?: ToastOptions) =>
+    toastify.error(message, { ...defaultOptions, ...options }),
+
+  warning: (message: string, options?: ToastOptions) =>
+    toastify.warning(message, { ...defaultOptions, ...options }),
+
+  info: (message: string, options?: ToastOptions) =>
+    toastify.info(message, { ...defaultOptions, ...options }),
+};


### PR DESCRIPTION
## 🔗 관련 이슈

- close #16
- close #17
- close #18

---

## 📌 주요 변경 사항

- Modal 공통 컴포넌트 구현 (Portal + focus-trap + ESC/오버레이 닫기)
- Toast 알림 설정 (react-toastify) + queryClient 글로벌 에러 핸들러 연동
- Badge 공통 컴포넌트 구현 (예매 상태별 색상)
- Skeleton 공통 컴포넌트 구현 (text/card/image/circle variant)

---

## 🛠 상세 구현 내용

### Modal (#16)
- `components/common/Modal/Modal.tsx`
- Portal 기반 렌더링, focus-trap-react로 접근성 확보
- ESC 키/오버레이 클릭으로 닫기 지원
- body 스크롤 잠금
- size: sm/md/lg 3종

### Toast (#17)
- `api/queryClient.ts` - 글로벌 onError에 toast 연동
- `utils/toast.ts` - severity별 toast 분기 유틸
- TanStack Query mutation/query 에러 자동 toast 표시

### Badge (#18)
- `components/common/Badge/Badge.tsx`
- 예매가능/예매불가/취소/환불 등 상태별 색상 매핑
- sm/md 사이즈

### Skeleton (#18)
- `components/common/Skeleton/Skeleton.tsx`
- text/card/image/circle 4종 variant
- 공연 카드 로딩에 ConcertCardSkeleton으로 활용

---

## ✅ 테스트

### 테스트 방법
- 로그인 페이지 → 결제 진행 중 모달 동작 확인
- 잘못된 로그인 시 toast 에러 노출 확인
- 공연 목록 로딩 중 Skeleton 표시 확인

### 테스트 결과
- [x] Modal Portal 정상 렌더링
- [x] ESC/오버레이 클릭 시 닫힘
- [x] focus-trap 동작 (Tab 키 모달 내 순환)
- [x] toast 글로벌 에러 핸들러 동작
- [x] `npx tsc --noEmit` 통과

---

## 👀 리뷰 요청 사항

- Modal size 종류가 적절한지 (sm/md/lg)
- toast 자동 닫힘 시간(3초)이 적절한지

---

## ⚠️ 배포 시 주의사항

- `react-toastify` 새 의존성 추가됨
- `focus-trap-react` 새 의존성 추가됨