### PR TITLE
[Feat] #19, 21, 22 Layout (Header/Footer/UserLayout/AdminLayout) + 로그인 + ProtectedRoute 구현

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,125 @@
+// 인증 API
+// USE_MOCK 플래그로 mock/real 분기 (백엔드 연동 시 false로)
+
+import apiClient from "./instance";
+import type {
+  SocialOauthLoginRequest,
+  OauthLoginResponse,
+  TokenReissueRequest,
+  TokenReissueResponse,
+  EmailLoginRequest,
+  EmailLoginResponse,
+} from "@/types/domain/auth";
+
+const USE_MOCK = true;
+
+/** 소셜 로그인 — swagger 확정: POST /api/v1/auth/social/login */
+export async function socialLoginApi(
+  req: SocialOauthLoginRequest,
+): Promise<OauthLoginResponse> {
+  if (USE_MOCK) {
+    const { mockSocialLogin } = await import("./mocks/auth");
+    return mockSocialLogin(req);
+  }
+  const res = await apiClient.post<OauthLoginResponse>(
+    "/api/v1/auth/social/login",
+    req,
+  );
+  return res.data;
+}
+
+/** 이메일 로그인 — 가상 스펙 (백엔드 확정 대기) */
+export async function emailLoginApi(
+  req: EmailLoginRequest,
+): Promise<EmailLoginResponse> {
+  if (USE_MOCK) {
+    const { mockEmailLogin } = await import("./mocks/auth");
+    return mockEmailLogin(req);
+  }
+  const res = await apiClient.post<EmailLoginResponse>(
+    "/api/v1/auth/login",
+    req,
+  );
+  return res.data;
+}
+
+/** 토큰 재발급 — swagger 확정: POST /api/v1/auth/reissue */
+export async function reissueTokenApi(
+  req: TokenReissueRequest,
+): Promise<TokenReissueResponse> {
+  if (USE_MOCK) {
+    const { mockReissue } = await import("./mocks/auth");
+    return mockReissue();
+  }
+  const res = await apiClient.post<TokenReissueResponse>(
+    "/api/v1/auth/reissue",
+    req,
+  );
+  return res.data;
+}
+
+/** OAuth URL 조회 — swagger 확정: GET /api/v1/auth/oauth/{provider}/url */
+export async function getOauthUrlApi(provider: string): Promise<string> {
+  if (USE_MOCK) {
+    const { mockOauthUrl } = await import("./mocks/auth");
+    return mockOauthUrl(provider);
+  }
+  const res = await apiClient.get<string>(`/api/v1/auth/oauth/${provider}/url`);
+  return res.data;
+}
+
+/** 로그아웃 — swagger 확정: POST /api/v1/auth/logout */
+export async function logoutApi(): Promise<void> {
+  if (USE_MOCK) {
+    const { mockLogout } = await import("./mocks/auth");
+    return mockLogout();
+  }
+  await apiClient.post("/api/v1/auth/logout");
+}
+
+// ─────────────────────────────────────────────────────
+// 이메일 인증 — 가상 스펙 (혜림 백엔드 확정 대기)
+// ─────────────────────────────────────────────────────
+
+/** 이메일 인증번호 발송 */
+export async function sendEmailVerificationApi(email: string): Promise<void> {
+  if (USE_MOCK) {
+    // 0.5초 지연 + mock에서는 항상 성공
+    await new Promise((r) => setTimeout(r, 500));
+    return;
+  }
+  await apiClient.post("/api/v1/auth/email/send-code", { email });
+}
+
+/** 이메일 인증번호 확인 */
+export async function verifyEmailCodeApi(
+  email: string,
+  code: string,
+): Promise<void> {
+  if (USE_MOCK) {
+    await new Promise((r) => setTimeout(r, 300));
+    // mock: "123456"이면 성공, 그 외 실패
+    if (code !== "123456") {
+      throw new Error("인증번호가 일치하지 않습니다.");
+    }
+    return;
+  }
+  await apiClient.post("/api/v1/auth/email/verify-code", { email, code });
+}
+
+/** 회원가입 */
+export async function signupApi(req: {
+  name: string;
+  email: string;
+  password: string;
+}): Promise<void> {
+  if (USE_MOCK) {
+    await new Promise((r) => setTimeout(r, 800));
+    // mock: exist@test.com이면 실패
+    if (req.email === "exist@test.com") {
+      throw { response: { status: 409 } };
+    }
+    return;
+  }
+  await apiClient.post("/api/v1/auth/signup", req);
+}

--- a/src/api/mocks/auth.ts
+++ b/src/api/mocks/auth.ts
@@ -1,0 +1,71 @@
+// Mock 인증
+import { mockDelay, mockError } from "./_helpers";
+import type {
+  OauthLoginResponse,
+  EmailLoginRequest,
+  EmailLoginResponse,
+  SocialOauthLoginRequest,
+  TokenReissueResponse,
+} from "@/types/domain/auth";
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+export async function mockSocialLogin(
+  req: SocialOauthLoginRequest,
+): Promise<OauthLoginResponse> {
+  await mockDelay(500);
+
+  return {
+    userId: 1,
+    name: `${req.provider}_TestUser`,
+    isNewUser: false,
+    accessToken: `mock-access-${Date.now()}`,
+    refreshToken: `mock-refresh-${Date.now()}`,
+    accessTokenExpiresIn: ONE_HOUR_MS,
+    refreshTokenExpiresIn: ONE_WEEK_MS,
+  };
+}
+
+export async function mockEmailLogin(
+  req: EmailLoginRequest,
+): Promise<EmailLoginResponse> {
+  await mockDelay(500);
+
+  // 실패 케이스 테스트용 — fail@test.com / password 외
+  if (req.email === "fail@test.com") {
+    await mockError(
+      "AUTH_LOGIN_FAILED",
+      "이메일 또는 비밀번호가 일치하지 않습니다.",
+    );
+  }
+
+  return {
+    userId: 1,
+    name: req.email.split("@")[0],
+    isNewUser: false,
+    accessToken: `mock-access-${Date.now()}`,
+    refreshToken: `mock-refresh-${Date.now()}`,
+    accessTokenExpiresIn: ONE_HOUR_MS,
+    refreshTokenExpiresIn: ONE_WEEK_MS,
+  };
+}
+
+export async function mockOauthUrl(provider: string): Promise<string> {
+  await mockDelay(200);
+  return `https://mock-oauth.example.com/${provider}?client_id=mock&redirect_uri=http://localhost:5173/oauth/callback`;
+}
+
+export async function mockLogout(): Promise<void> {
+  await mockDelay(200);
+}
+
+export async function mockReissue(): Promise<TokenReissueResponse> {
+  await mockDelay(300);
+  return {
+    accessToken: `mock-access-${Date.now()}`,
+    refreshToken: `mock-refresh-${Date.now()}`,
+    accessTokenExpiresIn: ONE_HOUR_MS,
+    refreshTokenExpiresIn: ONE_WEEK_MS,
+  };
+}

--- a/src/components/common/CircularTimer/CircularTimer.tsx
+++ b/src/components/common/CircularTimer/CircularTimer.tsx
@@ -1,0 +1,135 @@
+// src/components/common/CircularTimer/CircularTimer.tsx
+import { useMemo } from "react";
+
+interface CircularTimerProps {
+  /** 남은 시간 (초) */
+  remainingSeconds: number;
+  /** 전체 시간 (초) — 기본 300초(5분) */
+  totalSeconds?: number;
+  /** SVG 크기 (px) — 기본 280 */
+  size?: number;
+  /** 호 두께 (px) — 기본 18 */
+  strokeWidth?: number;
+}
+
+/**
+ * 좌석 임시 예약 카운트다운 타이머 (4개 호 디자인)
+ *
+ * ─ 운영 정책 ────────────────────────────────────────
+ * [카운트다운 및 프로그레스 바 로직]
+ *  - 프로그레스 바 동기화: 남은 시간에 비례하여 원형 프로그레스가 줄어듦
+ *  - 1분 미만: 빨간색(#C10007) 변경
+ *
+ * [디자인 가이드]
+ *  - 원형 프로그레스: 보라색(#6C5CE7), SVG 기반
+ *  - 카운트다운 텍스트: 큰 폰트, 1분 미만 시 빨간색
+ *  - "남은 시간" 텍스트 하단 배치
+ * ────────────────────────────────────────────────────
+ *
+ * ─ 디자인 ──────────────────────────────────────────
+ * 원이 4개의 호로 분할된 형태 (12·3·6·9시 방향에 호 중심).
+ * 진행률에 따라 보라색 호가 시계 방향으로 줄어들면서
+ * 뒤의 회색 호가 드러나는 구조.
+ * ────────────────────────────────────────────────────
+ *
+ * @example
+ * <CircularTimer remainingSeconds={298} />
+ *
+ * timerStore의 remainingMs와 함께 사용:
+ * const remainingMs = useTimerStore(s => s.remainingMs);
+ * <CircularTimer remainingSeconds={Math.ceil(remainingMs / 1000)} />
+ */
+export function CircularTimer({
+  remainingSeconds,
+  totalSeconds = 300,
+  size = 280,
+  strokeWidth = 18,
+}: CircularTimerProps) {
+  // 0 이하 또는 totalSeconds 초과 방어
+  const clampedRemaining = Math.max(
+    0,
+    Math.min(remainingSeconds, totalSeconds),
+  );
+
+  // SVG 기하 계산 (useMemo로 size/strokeWidth 변경 시에만 재계산)
+  const geometry = useMemo(() => {
+    const radius = (size - strokeWidth) / 2;
+    const circumference = 2 * Math.PI * radius;
+
+    // 4개 호로 분할: 호:갭 = 7:3
+    const SEGMENTS = 4;
+    const ARC_RATIO = 0.7;
+    const segmentLength = circumference / SEGMENTS;
+    const arcLength = segmentLength * ARC_RATIO;
+    const gapLength = segmentLength - arcLength;
+
+    return { radius, circumference, arcLength, gapLength };
+  }, [size, strokeWidth]);
+
+  // 진행률 — 남은 시간에 비례 (운영 정책: "타이머의 남은 시간과 비례")
+  const progress = clampedRemaining / totalSeconds;
+  const dashOffset = geometry.circumference * (1 - progress);
+
+  // 운영 정책: 1분 미만 빨간색 변경
+  const isWarning = clampedRemaining < 60;
+  const progressColor = isWarning ? "#C10007" : "#6C5CE7";
+
+  // 시간 포맷팅 (M:SS)
+  const minutes = Math.floor(clampedRemaining / 60);
+  const seconds = clampedRemaining % 60;
+  const timeText = `${minutes}:${seconds.toString().padStart(2, "0")}`;
+
+  const center = size / 2;
+  const dashArray = `${geometry.arcLength} ${geometry.gapLength}`;
+
+  return (
+    <div className="relative inline-flex flex-col items-center justify-center">
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        role="img"
+        aria-label={`남은 시간 ${minutes}분 ${seconds}초`}
+      >
+        {/* 배경 — 회색 4개 호 (항상 표시) */}
+        <circle
+          cx={center}
+          cy={center}
+          r={geometry.radius}
+          fill="none"
+          stroke="#E5E7EB"
+          strokeWidth={strokeWidth}
+          strokeDasharray={dashArray}
+          strokeLinecap="round"
+          transform={`rotate(-90 ${center} ${center})`}
+        />
+        {/* 진행 — 보라색 호 (시간 지나면서 줄어듦) */}
+        <circle
+          cx={center}
+          cy={center}
+          r={geometry.radius}
+          fill="none"
+          stroke={progressColor}
+          strokeWidth={strokeWidth}
+          strokeDasharray={dashArray}
+          strokeDashoffset={dashOffset}
+          strokeLinecap="round"
+          transform={`rotate(-90 ${center} ${center})`}
+          className="transition-[stroke-dashoffset,stroke] duration-1000 ease-linear"
+        />
+      </svg>
+
+      {/* 중앙 텍스트 — SVG 위에 absolute 배치 */}
+      <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+        <span
+          className={`text-5xl font-bold tabular-nums leading-none ${
+            isWarning ? "text-[#C10007]" : "text-primary"
+          }`}
+        >
+          {timeText}
+        </span>
+        <span className="mt-3 text-sm text-gray-500">남은 시간</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -1,0 +1,91 @@
+// components/layout/AdminLayout.tsx
+import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
+import {
+  LayoutDashboard,
+  Ticket,
+  Activity,
+  PlusSquare,
+  RotateCcw,
+  ArrowLeft,
+} from "lucide-react";
+import useAuthStore from "../../stores/global/authStore";
+
+const navItems = [
+  { to: "/admin", label: "대시보드", icon: LayoutDashboard, exact: true },
+  { to: "/admin/bookings", label: "예매 내역", icon: Ticket },
+  { to: "/admin/seat-monitoring", label: "좌석 모니터링", icon: Activity },
+  { to: "/admin/concerts/new", label: "공연 등록", icon: PlusSquare },
+  { to: "/admin/refunds", label: "환불 관리", icon: RotateCcw },
+];
+
+export default function AdminLayout() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const user = useAuthStore((s) => s.user);
+
+  const isActive = (to: string, exact?: boolean) =>
+    exact ? location.pathname === to : location.pathname.startsWith(to);
+
+  return (
+    <div className="min-h-screen flex bg-admin-bg text-admin-text">
+      {/* 사이드바 */}
+      <aside className="w-64 bg-admin-card border-r border-admin-border flex flex-col">
+        {/* 로고 */}
+        <div className="px-6 py-5 border-b border-admin-border">
+          <p className="font-pretendard text-xs text-admin-text-secondary tracking-wider">
+            ADMIN MODE
+          </p>
+          <p className="font-pretendard text-lg font-bold mt-1">TicketRush</p>
+        </div>
+
+        {/* 내비게이션 */}
+        <nav className="flex-1 px-3 py-4 space-y-1">
+          {navItems.map(({ to, label, icon: Icon, exact }) => (
+            <Link
+              key={to}
+              to={to}
+              className={[
+                "flex items-center gap-3 px-3 py-2.5 rounded-lg",
+                "font-pretendard text-sm transition-colors",
+                isActive(to, exact)
+                  ? "bg-primary text-white"
+                  : "text-admin-text-secondary hover:bg-admin-border hover:text-admin-text",
+              ].join(" ")}
+            >
+              <Icon size={18} />
+              {label}
+            </Link>
+          ))}
+        </nav>
+
+        {/* 하단 — 사용자 정보 + 사용자 모드로 */}
+        <div className="px-3 py-4 border-t border-admin-border">
+          {user && (
+            <div className="px-3 py-2 mb-2">
+              <p className="font-pretendard text-xs text-admin-text-secondary">
+                로그인됨
+              </p>
+              <p className="font-pretendard text-sm font-medium truncate">
+                {user.name}
+              </p>
+            </div>
+          )}
+          <button
+            onClick={() => navigate("/")}
+            className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg
+              font-pretendard text-sm text-admin-text-secondary
+              hover:bg-admin-border hover:text-admin-text transition-colors"
+          >
+            <ArrowLeft size={18} />
+            사용자 모드로
+          </button>
+        </div>
+      </aside>
+
+      {/* 메인 영역 */}
+      <main className="flex-1 overflow-auto">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/src/components/layout/AdminRoute.tsx
+++ b/src/components/layout/AdminRoute.tsx
@@ -1,0 +1,32 @@
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+import useAuthStore from "../../stores/global/authStore";
+
+// 관리자만 접근 가능한 라우트를 보호하는 가드 컴포넌트
+
+// - 비로그인 → /login (원래 URL을 state로 전달)
+// - 로그인했지만 관리자가 아님 → / (홈)
+
+// 사용 예:
+//   <Route element={<AdminRoute />}>
+//     <Route element={<AdminLayout />}>
+//       <Route path="/admin" element={<Dashboard />} />
+//     </Route>
+//   </Route>
+
+export default function AdminRoute() {
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const user = useAuthStore((s) => s.user);
+  const location = useLocation();
+
+  // 비로그인
+  if (!accessToken) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  // 관리자 권한 없음
+  if (user?.role !== "ADMIN") {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,62 @@
+import logo from "@/assets/images/logo.svg";
+
+export default function Footer() {
+  return (
+    <footer className="bg-white border-t border-border mt-auto">
+      <div className="max-w-[1280px] mx-auto px-6 py-6">
+        <div className="grid grid-cols-3 items-center gap-4">
+          {/* 왼쪽: 링크 + 카피라이트 */}
+          <div className="font-pretendard text-xs text-text-secondary space-y-1">
+            <p>
+              TicketRush ·{" "}
+              <a
+                href="https://github.com/your-org/ticketrush"
+                target="_blank"
+                rel="noreferrer"
+                className="hover:text-primary"
+              >
+                GitHub
+              </a>{" "}
+              ·{" "}
+              <a href="/api-docs" className="hover:text-primary">
+                API Docs
+              </a>
+            </p>
+            <p>
+              Copyright © 2026 TicketRush. All issues discussed via GitHub
+              Discussions.
+            </p>
+          </div>
+
+          {/* 가운데: 로고 */}
+          <div className="flex justify-center">
+            <span className="font-pretendard text-2xl font-bold text-text">
+              <img src={logo} alt="TicketRush" className="h-8 w-auto" />
+            </span>
+            {/* 손글씨 스타일 폰트 적용하려면 아래 "💡 손글씨 로고" 참고 */}
+          </div>
+
+          {/* 오른쪽: 정책 링크 */}
+          <div className="flex justify-end gap-6 font-pretendard text-xs text-text-secondary">
+            <a
+              href="https://orange-split-b03.notion.site/TicketRush-35fbd63b04d5802cb228d07f783fd720?source=copy_link"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-primary"
+            >
+              개인정보처리방침
+            </a>
+            <a
+              href="https://orange-split-b03.notion.site/TicketRush-35fbd63b04d580eab531c4f5cf6c2fb1?source=copy_link"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-primary"
+            >
+              이용약관
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,48 @@
+import { Link, useNavigate } from "react-router-dom";
+import useAuthStore from "../../stores/global/authStore";
+import Button from "../common/Button/Button";
+import logo from "@/assets/images/logo.svg";
+
+export default function Header() {
+  const navigate = useNavigate();
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const logout = useAuthStore((s) => s.logout);
+  const isLoggedIn = !!accessToken;
+
+  const handleLogout = () => {
+    logout();
+    navigate("/");
+  };
+
+  return (
+    <header className="sticky top-0 z-40 bg-white border-b border-border">
+      <div className="max-w-[1280px] mx-auto px-6 h-16 flex items-center justify-between">
+        <Link to="/">
+          <img src={logo} alt="TicketRush" className="h-8 w-auto" />
+        </Link>
+
+        {/* 메뉴 */}
+        <nav className="flex items-center gap-2">
+          {isLoggedIn ? (
+            <>
+              <Link to="/reservations/mypage">
+                <Button variant="secondary" size="sm">
+                  내 예매
+                </Button>
+              </Link>
+              <Button variant="secondary" size="sm" onClick={handleLogout}>
+                로그아웃
+              </Button>
+            </>
+          ) : (
+            <Link to="/login">
+              <Button variant="primary" size="sm">
+                로그인
+              </Button>
+            </Link>
+          )}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/src/components/layout/ProtectedRoute.tsx
+++ b/src/components/layout/ProtectedRoute.tsx
@@ -1,0 +1,23 @@
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+import useAuthStore from "../../stores/global/authStore";
+
+// 인증이 필요한 라우트를 보호하는 가드 컴포넌트
+//
+// - accessToken이 없으면 /login으로 리다이렉트
+// - 현재 URL을 state.from에 저장 → 로그인 후 원래 위치로 복귀
+//
+// 사용 예:
+//   <Route element={<ProtectedRoute />}>
+//     <Route path="/reservations/mypage" element={<MyBookings />} />
+//   </Route>
+
+export default function ProtectedRoute() {
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const location = useLocation();
+
+  if (!accessToken) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/components/layout/UserLayout.tsx
+++ b/src/components/layout/UserLayout.tsx
@@ -1,0 +1,16 @@
+// components/layout/UserLayout.tsx
+import { Outlet } from "react-router-dom";
+import Header from "./Header";
+import Footer from "./Footer";
+
+export default function UserLayout() {
+  return (
+    <div className="min-h-screen flex flex-col bg-[#f8f9fa]">
+      <Header />
+      <main className="flex-1">
+        <Outlet />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/hooks/auth/useAuth.ts
+++ b/src/hooks/auth/useAuth.ts
@@ -1,0 +1,79 @@
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { socialLoginApi, emailLoginApi, logoutApi } from "@/api/auth";
+import useAuthStore from "@/stores/global/authStore";
+
+// ⚠️ Dev/데모용 — 관리자 계정 화이트리스트
+//    백엔드에서 응답에 role 필드를 추가하면 이 화이트리스트는 제거
+const ADMIN_EMAIL_WHITELIST = ["admin@ticketrush.com"];
+
+function determineRole(email: string, backendRole?: string): "ADMIN" | "USER" {
+  // 백엔드가 role을 주면 그게 우선 (백엔드 연동 후 자연스럽게 전환)
+  if (backendRole === "ADMIN") return "ADMIN";
+  // 화이트리스트 fallback
+  if (ADMIN_EMAIL_WHITELIST.includes(email.toLowerCase().trim())) {
+    return "ADMIN";
+  }
+  return "USER";
+}
+
+export function useSocialLogin() {
+  const setAuth = useAuthStore((s) => s.setAuth);
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: socialLoginApi,
+    onSuccess: (data) => {
+      // 소셜 로그인은 응답에 email이 없음 → 일반 USER로 처리
+      // (관리자 시연은 이메일 로그인으로만)
+      setAuth(data.accessToken, {
+        userId: data.userId,
+        name: data.name,
+        email: "",
+        role: "USER",
+      });
+      navigate("/");
+    },
+  });
+}
+
+export function useEmailLogin() {
+  const setAuth = useAuthStore((s) => s.setAuth);
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: emailLoginApi,
+    onSuccess: (data, variables) => {
+      // variables = mutationFn에 넘긴 req (이메일 포함)
+      const email = variables.email;
+      const role = determineRole(email);
+
+      setAuth(data.accessToken, {
+        userId: data.userId,
+        name: data.name,
+        email,
+        role,
+      });
+
+      // 관리자면 admin 대시보드로, 일반 사용자는 홈으로
+      navigate(role === "ADMIN" ? "/admin" : "/");
+    },
+  });
+}
+
+export function useLogout() {
+  const logout = useAuthStore((s) => s.logout);
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: logoutApi,
+    onSuccess: () => {
+      logout();
+      navigate("/login");
+    },
+    onError: () => {
+      logout();
+      navigate("/login");
+    },
+  });
+}

--- a/src/pages/Auth/LoginPage.tsx
+++ b/src/pages/Auth/LoginPage.tsx
@@ -1,0 +1,134 @@
+import { useEffect } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { loginSchema, type LoginFormData } from "../../schemas/auth";
+import { useEmailLogin } from "@/hooks/auth/useAuth";
+import Button from "../../components/common/Button/Button";
+import Input from "../../components/common/Input/Input";
+
+export default function LoginPage() {
+  const navigate = useNavigate();
+  const emailLogin = useEmailLogin();
+
+  const {
+    register,
+    handleSubmit,
+    setFocus,
+    setError,
+    formState: { errors },
+  } = useForm<LoginFormData>({
+    resolver: zodResolver(loginSchema),
+  });
+
+  useEffect(() => {
+    setFocus("email");
+  }, [setFocus]);
+
+  const onSubmit = (data: LoginFormData) => {
+    emailLogin.mutate(data, {
+      onError: (error: unknown) => {
+        const err = error as {
+          response?: { status?: number };
+          message?: string;
+        };
+        if (err?.response?.status === 401) {
+          setError("root", {
+            message: "이메일 또는 비밀번호가 올바르지 않습니다",
+          });
+        } else {
+          setError("root", {
+            message: err?.message ?? "로그인 중 오류가 발생했습니다",
+          });
+        }
+      },
+    });
+  };
+
+  return (
+    <div className="relative flex justify-center min-h-screen px-6 pt-20 pb-10 bg-[#f8f9fa]">
+      <div className="absolute top-6 left-6">
+        <Button variant="secondary" size="sm" onClick={() => navigate(-1)}>
+          ← 뒤로가기
+        </Button>
+      </div>
+
+      <div className="w-full max-w-[480px] px-10 py-12 bg-white rounded-2xl border border-border self-start">
+        <h1 className="font-pretendard text-[28px] font-bold text-text mb-2">
+          로그인
+        </h1>
+        <p className="font-pretendard text-base text-text-secondary mb-8">
+          계정에 로그인하세요
+        </p>
+
+        <form
+          className="flex flex-col gap-5"
+          onSubmit={handleSubmit(onSubmit)}
+          noValidate
+        >
+          <Input
+            label="이메일"
+            icon={<span>✉</span>}
+            required
+            type="email"
+            placeholder="user@example.com"
+            error={errors.email?.message}
+            {...register("email")}
+          />
+          <Input
+            label="비밀번호"
+            icon={<span>🔒</span>}
+            required
+            type="password"
+            placeholder="비밀번호를 입력해주세요"
+            error={errors.password?.message}
+            {...register("password")}
+          />
+
+          {errors.root && (
+            <p className="font-pretendard text-sm text-error text-center">
+              {errors.root.message}
+            </p>
+          )}
+
+          <Button
+            type="submit"
+            variant="primary"
+            size="lg"
+            fullWidth
+            loading={emailLogin.isPending}
+          >
+            로그인
+          </Button>
+        </form>
+
+        <div className="flex items-center gap-4 my-7">
+          <div className="flex-1 h-px bg-border" />
+          <span className="font-pretendard text-sm text-text-secondary whitespace-nowrap">
+            간편 로그인
+          </span>
+          <div className="flex-1 h-px bg-border" />
+        </div>
+
+        <div className="flex gap-3">
+          <Button variant="kakao" size="md" className="flex-1">
+            카카오
+          </Button>
+          <Button variant="naver" size="md" className="flex-1">
+            네이버
+          </Button>
+          <Button variant="google" size="md" className="flex-1">
+            구글
+          </Button>
+        </div>
+
+        <p className="font-pretendard text-sm text-text-secondary text-center mt-6">
+          계정이 없으신가요?{" "}
+          <Link to="/signup" className="text-primary font-semibold underline">
+            회원가입
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -18,6 +18,10 @@ export const signupSchema = z
       .min(1, "이메일을 입력해주세요")
       .email("올바른 이메일을 입력해주세요"),
     verificationCode: z.string().min(1, "인증 번호를 입력해주세요"),
+    /** 이메일 인증 완료 여부 — UI 상태이지만 폼 검증에 필요 */
+    isEmailVerified: z.boolean().refine((val) => val === true, {
+      message: "이메일 인증을 완료해주세요",
+    }),
     password: z.string().min(8, "비밀번호는 8자 이상이어야 합니다"),
     passwordConfirm: z.string().min(1, "비밀번호 확인을 입력해주세요"),
   })

--- a/src/stores/global/authStore.ts
+++ b/src/stores/global/authStore.ts
@@ -5,7 +5,7 @@ import { devtools, persist } from "zustand/middleware";
 // HttpOnly Cookie 사용 시 수정
 interface AuthState {
   accessToken: string | null;
-  user: { name: string; email: string; role: string } | null;
+  user: { userId: number; name: string; email: string; role: string } | null;
   setAuth: (token: string, user: AuthState["user"]) => void;
   logout: () => void;
 }

--- a/src/stores/reservation/timerStore.ts
+++ b/src/stores/reservation/timerStore.ts
@@ -1,0 +1,114 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { useEffect } from "react";
+
+type TimerStatus = "idle" | "running" | "expired";
+
+interface TimerState {
+  status: TimerStatus;
+  remainingMs: number;
+  durationMs: number;
+
+  /** 타이머 시작 (default 5분) */
+  startTimer: (durationMs?: number) => void;
+  /** 타이머 정지 (정상 종료 — 결제 성공 시) */
+  stopTimer: () => void;
+  /** 모든 상태 초기화 */
+  reset: () => void;
+}
+
+const DEFAULT_DURATION_MS = 5 * 60 * 1000;
+
+// 모듈 스코프 — store 외부에 interval ID 보관 (state에 넣으면 비교 리렌더 발생)
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+function clearTimerInterval() {
+  if (intervalId !== null) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+export const useTimerStore = create<TimerState>()(
+  devtools(
+    (set) => ({
+      status: "idle",
+      remainingMs: 0,
+      durationMs: DEFAULT_DURATION_MS,
+
+      startTimer: (durationMs = DEFAULT_DURATION_MS) => {
+        clearTimerInterval();
+        const endsAt = Date.now() + durationMs;
+
+        set({ status: "running", durationMs, remainingMs: durationMs });
+
+        // 250ms 간격으로 갱신 — CircularTimer가 부드럽게 줄어들도록
+        intervalId = setInterval(() => {
+          const remaining = Math.max(0, endsAt - Date.now());
+
+          if (remaining <= 0) {
+            clearTimerInterval();
+            set({ status: "expired", remainingMs: 0 });
+          } else {
+            set({ remainingMs: remaining });
+          }
+        }, 250);
+      },
+
+      stopTimer: () => {
+        clearTimerInterval();
+        set({ status: "idle", remainingMs: 0 });
+      },
+
+      reset: () => {
+        clearTimerInterval();
+        set({
+          status: "idle",
+          remainingMs: 0,
+          durationMs: DEFAULT_DURATION_MS,
+        });
+      },
+    }),
+    { name: "TimerStore" },
+  ),
+);
+
+// ─────────────────────────────────────────────────────────
+// Convenience hooks
+// ─────────────────────────────────────────────────────────
+
+/**
+ * 타이머가 expired 상태로 전이되는 순간을 감지하여 콜백 실행.
+ * - status가 'expired'로 바뀌는 순간 한 번만 호출됨
+ * - 콜백 안에서 reset() 호출하면 다음 진입 시 중복 실행 방지
+ *
+ * @example
+ *   useTimerExpiry(() => {
+ *     paymentStore.expire();
+ *     navigate("/payment/expired");
+ *   });
+ */
+export function useTimerExpiry(onExpire: () => void) {
+  const status = useTimerStore((s) => s.status);
+  useEffect(() => {
+    if (status === "expired") onExpire();
+    // onExpire는 매 렌더마다 새 함수일 수 있어 의존성에서 제외 (필요 시 useCallback)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status]);
+}
+
+/** 남은 시간을 mm:ss 포맷으로 (CircularTimer 등에서 사용) */
+export function useTimerDisplay() {
+  const remainingMs = useTimerStore((s) => s.remainingMs);
+  const durationMs = useTimerStore((s) => s.durationMs);
+
+  const totalSec = Math.ceil(remainingMs / 1000);
+  const mm = Math.floor(totalSec / 60);
+  const ss = totalSec % 60;
+  const formatted = `${String(mm).padStart(2, "0")}:${String(ss).padStart(2, "0")}`;
+  const progress = durationMs > 0 ? remainingMs / durationMs : 0;
+
+  return { mm, ss, formatted, remainingMs, progress };
+}
+
+export default useTimerStore;

--- a/src/types/domain/auth.ts
+++ b/src/types/domain/auth.ts
@@ -1,0 +1,49 @@
+// 인증/유저 도메인 타입
+// swagger 확정: SocialOauthLoginRequest, OauthLoginResponse, TokenReissueRequest, TokenReissueResponse
+// 가상 스펙: EmailLoginRequest, EmailLoginResponse (백엔드 확정 대기)
+
+export type OauthProvider = "KAKAO" | "NAVER" | "GOOGLE";
+
+// ── 소셜 로그인 (swagger 확정) ─────────────────────
+export interface SocialOauthLoginRequest {
+  provider: OauthProvider;
+  code: string;
+}
+
+export interface OauthLoginResponse {
+  userId: number;
+  name: string;
+  isNewUser: boolean;
+  accessToken: string;
+  refreshToken: string;
+  /** ms 단위로 가정 (swagger int64) */
+  accessTokenExpiresIn: number;
+  refreshTokenExpiresIn: number;
+}
+
+// ── 이메일 로그인 (가상) ────────────────────────────
+export interface EmailLoginRequest {
+  email: string;
+  password: string;
+}
+
+/** 이메일 로그인 응답은 OauthLoginResponse와 동일 shape 가정 */
+export type EmailLoginResponse = OauthLoginResponse;
+
+// ── 토큰 재발급 ─────────────────────────────────────
+export interface TokenReissueRequest {
+  refreshToken: string;
+}
+
+export interface TokenReissueResponse {
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresIn: number;
+  refreshTokenExpiresIn: number;
+}
+
+// ── User 도메인 ──────────────────────────────────────
+export interface User {
+  userId: number;
+  name: string;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #19
- close #21
- close #22

---

## 📌 주요 변경 사항

- Header, Footer 컴포넌트 구현
- UserLayout (Header + Outlet + Footer) 구현
- AdminLayout (다크 테마 + 사이드바) 구현
- 이메일 로그인 페이지 구현 + admin 화이트리스트 분기
- ProtectedRoute (로그인 가드) + AdminRoute (role 기반 가드) 구현

---

## 🛠 상세 구현 내용

### Layout (#19)
- `components/layout/Header.tsx` - 로고/네비/로그인 버튼
- `components/layout/Footer.tsx`
- `components/layout/UserLayout.tsx` - 사용자 영역 공통 레이아웃
- `components/layout/AdminLayout.tsx` - 관리자 다크 테마 + 사이드바 + navItems

### 로그인 (#21)
- `pages/Auth/LoginPage.tsx` - 이메일/비밀번호 + 소셜 로그인 진입
- `hooks/auth/useAuth.ts` - useEmailLogin/useSocialLogin/useLogout
- `stores/global/authStore.ts` - accessToken + user 저장 (persist)
- `api/auth.ts`, `api/mocks/auth.ts` - 로그인/회원가입 API
- `types/domain/auth.ts` - 응답 타입 (userId, name, email, role, joinedAt)
- 관리자 화이트리스트: `admin@ticketrush.com` 로그인 시 role=ADMIN → `/admin` 자동 이동

### Gard (#22)
- `components/layout/ProtectedRoute.tsx` - 비로그인 시 `/login`으로
- `components/layout/AdminRoute.tsx` - role=USER 시 `/`로 리다이렉트

---

## ✅ 테스트

### 테스트 방법
- 비로그인 상태로 `/concerts/:id/seats` 접속 → 로그인 페이지 리다이렉트 확인
- 일반 USER로 `/admin` 접속 → 홈 리다이렉트 확인
- `admin@ticketrush.com` 로그인 → 자동으로 `/admin` 이동 확인

### 테스트 결과
- [x] 로그인 후 토큰 + user 정보 authStore 저장
- [x] 새로고침 후 로그인 상태 유지 (persist)
- [x] ProtectedRoute / AdminRoute 분기 정상
- [x] `npx tsc --noEmit` 통과

---

## 👀 리뷰 요청 사항

- 관리자 화이트리스트는 임시 처리이며 백엔드 role 응답 추가 후 제거 예정
- AdminLayout 사이드바 navItems가 실제 라우트랑 일치하는지

---

## ⚠️ 배포 시 주의사항

- 백엔드 로그인 응답에 `email`, `role`, `joinedAt` 필드가 포함돼야 함
- mock에 admin 계정 별도 없음 (화이트리스트로 분기)