### PR TITLE
[Feat] #25, 26, 28 공연 카드/메인 그리드 + 배너 슬라이더 + 예매 안내 (BookingSidebar) 구현

### DIFF
--- a/src/api/banners.ts
+++ b/src/api/banners.ts
@@ -1,0 +1,12 @@
+import { mockGetBanners } from "./mocks/banners";
+// import apiClient from "./instance";
+
+const USE_MOCK = true;
+
+export async function fetchBanners() {
+  if (USE_MOCK) return mockGetBanners();
+  // TODO: 민주 백엔드 API 완성 시 교체
+  // const res = await apiClient.get("/api/v1/banners");
+  // return res.data;
+  throw new Error("Real banners API not implemented");
+}

--- a/src/api/concerts.ts
+++ b/src/api/concerts.ts
@@ -1,0 +1,90 @@
+// 공연 API — 가상 스펙 (백엔드 performance-service swagger 확정 대기)
+
+import type {
+  ConcertDetail,
+  ConcertListParams,
+  ConcertListResponse,
+} from "@/types/domain/concert";
+import { MOCK_CONCERTS, getMockConcertDetail } from "./mocks/concerts";
+import { mockDelay, mockError } from "./mocks/_helpers";
+// import apiClient from "./instance"; // 실 API 시 주석 해제
+
+const USE_MOCK = true;
+
+export async function fetchConcerts(
+  params: ConcertListParams = {},
+): Promise<ConcertListResponse> {
+  if (USE_MOCK) {
+    await mockDelay();
+
+    let filtered = [...MOCK_CONCERTS];
+
+    if (params.genre) {
+      filtered = filtered.filter((c) => c.genre === params.genre);
+    }
+    if (params.status) {
+      filtered = filtered.filter((c) => c.status === params.status);
+    }
+    if (params.minPrice !== undefined) {
+      filtered = filtered.filter((c) => c.price >= params.minPrice!);
+    }
+    if (params.maxPrice !== undefined) {
+      filtered = filtered.filter((c) => c.price <= params.maxPrice!);
+    }
+    if (params.keyword) {
+      const kw = params.keyword.toLowerCase();
+      filtered = filtered.filter(
+        (c) =>
+          c.title.toLowerCase().includes(kw) ||
+          c.artist.toLowerCase().includes(kw),
+      );
+    }
+
+    // 정렬
+    if (params.sort === "PRICE_ASC") {
+      filtered.sort((a, b) => a.price - b.price);
+    } else if (params.sort === "PRICE_DESC") {
+      filtered.sort((a, b) => b.price - a.price);
+    } else if (params.sort === "POPULAR") {
+      // 잔여석 비율이 낮을수록 인기
+      filtered.sort(
+        (a, b) =>
+          a.remainingSeats / a.totalSeats - b.remainingSeats / b.totalSeats,
+      );
+    }
+    // LATEST는 기본 순서 유지
+
+    // Cursor 페이지네이션
+    const size = params.size ?? 10;
+    const cursor = params.cursor ?? 0;
+    const items = filtered.slice(cursor, cursor + size);
+
+    return {
+      items,
+      pagination: {
+        hasNext: cursor + size < filtered.length,
+        nextCursor: cursor + size,
+        size,
+      },
+    };
+  }
+
+  // 실 API (가상 엔드포인트)
+  // const res = await apiClient.get<ConcertListResponse>("/api/v1/performance", { params });
+  // return res.data;
+  throw new Error("Real API not implemented");
+}
+
+export async function fetchConcertDetail(id: number): Promise<ConcertDetail> {
+  if (USE_MOCK) {
+    await mockDelay();
+    const detail = getMockConcertDetail(id);
+    if (!detail) {
+      await mockError("CONCERT_NOT_FOUND", "공연을 찾을 수 없습니다.");
+    }
+    return detail!;
+  }
+  // const res = await apiClient.get<ConcertDetail>(`/api/v1/performance/${id}`);
+  // return res.data;
+  throw new Error("Real API not implemented");
+}

--- a/src/api/mocks/banners.ts
+++ b/src/api/mocks/banners.ts
@@ -1,0 +1,40 @@
+import type { BannerItem } from "@/types/domain/banner";
+import { mockDelay } from "./_helpers";
+
+const MOCK_BANNERS: BannerItem[] = [
+  {
+    id: 1,
+    title: "Summer Jazz Night",
+    subtitle: "여름밤의 재즈 향연",
+    description: "세계적인 재즈 뮤지션과 함께하는 특별한 밤",
+    tagLabel: "조기 예매 할인",
+    iconEmoji: "🎵",
+    date: "2026-06-15",
+    order: 1,
+  },
+  {
+    id: 2,
+    title: "K-Pop Mega Concert",
+    subtitle: "최고의 아이돌 스타 집결",
+    description: "팬들이 기다린 드림 라인업 공개!",
+    tagLabel: "VIP 패키지 판매중",
+    iconEmoji: "🎤",
+    date: "2026-07-20",
+    order: 2,
+  },
+  {
+    id: 3,
+    title: "Classical Gala",
+    subtitle: "클래식의 정수를 만나다",
+    description: "세계 3대 오케스트라 내한 공연",
+    tagLabel: "프리미엄 좌석 한정",
+    iconEmoji: "🎹",
+    date: "2026-08-10",
+    order: 3,
+  },
+];
+
+export async function mockGetBanners(): Promise<BannerItem[]> {
+  await mockDelay(300);
+  return [...MOCK_BANNERS].sort((a, b) => a.order - b.order);
+}

--- a/src/api/mocks/concerts.ts
+++ b/src/api/mocks/concerts.ts
@@ -1,0 +1,144 @@
+/**
+ * Mock 공연 데이터
+ * ⚠️ 백엔드 performance-service swagger 확정 시 정렬 필요
+ */
+import type {
+  ConcertSummary,
+  ConcertDetail,
+} from "@/types/domain/concert";
+import { mockDelay } from "./_helpers";
+
+const POSTER = "/placeholder-poster.png";
+
+export const MOCK_CONCERTS: ConcertSummary[] = [
+  {
+    id: 1,
+    title: "BTS World Tour: Beyond the Stars",
+    artist: "BTS",
+    genre: "CONCERT",
+    venue: "잠실 올림픽 주경기장",
+    date: "2026-07-20",
+    time: "18:00",
+    price: 132000,
+    posterUrl: POSTER,
+    totalSeats: 120,
+    remainingSeats: 23,
+    status: "ON_SALE",
+  },
+  {
+    id: 2,
+    title: "The Phantom of the Opera",
+    artist: "뮤지컬 앙상블",
+    genre: "MUSICAL",
+    venue: "블루스퀘어 신한카드홀",
+    date: "2026-06-15",
+    time: "19:30",
+    price: 88000,
+    posterUrl: POSTER,
+    totalSeats: 120,
+    remainingSeats: 0,
+    status: "SOLD_OUT",
+  },
+  {
+    id: 3,
+    title: "Classical Evening: Beethoven Symphony",
+    artist: "서울시향",
+    genre: "CLASSIC",
+    venue: "예술의전당 콘서트홀",
+    date: "2026-08-10",
+    time: "19:00",
+    price: 55000,
+    posterUrl: POSTER,
+    totalSeats: 120,
+    remainingSeats: 87,
+    status: "ON_SALE",
+  },
+  {
+    id: 4,
+    title: "Jazz Night Live",
+    artist: "나윤선 트리오",
+    genre: "JAZZ",
+    venue: "LG아트센터",
+    date: "2026-06-28",
+    time: "20:00",
+    price: 66000,
+    posterUrl: POSTER,
+    totalSeats: 120,
+    remainingSeats: 45,
+    status: "ON_SALE",
+  },
+  {
+    id: 5,
+    title: "Ultra Music Festival Korea",
+    artist: "Various Artists",
+    genre: "FESTIVAL",
+    venue: "난지한강공원",
+    date: "2026-09-05",
+    time: "14:00",
+    price: 154000,
+    posterUrl: POSTER,
+    totalSeats: 120,
+    remainingSeats: 12,
+    status: "ON_SALE",
+  },
+  {
+    id: 6,
+    title: "BLACKPINK Fan Meeting",
+    artist: "BLACKPINK",
+    genre: "FANMEETING",
+    venue: "KSPO DOME",
+    date: "2026-07-01",
+    time: "17:00",
+    price: 99000,
+    posterUrl: POSTER,
+    totalSeats: 120,
+    remainingSeats: 3,
+    status: "ON_SALE",
+  },
+  {
+    id: 7,
+    title: "Swan Lake",
+    artist: "국립발레단",
+    genre: "BALLET",
+    venue: "예술의전당 오페라극장",
+    date: "2026-08-22",
+    time: "15:00",
+    price: 77000,
+    posterUrl: POSTER,
+    totalSeats: 120,
+    remainingSeats: 56,
+    status: "ON_SALE",
+  },
+];
+
+export function getMockConcertDetail(id: number): ConcertDetail | null {
+  const summary = MOCK_CONCERTS.find((c) => c.id === id);
+  if (!summary) return null;
+
+  return {
+    ...summary,
+    description:
+      `${summary.title}의 특별한 공연이 ${summary.venue}에서 펼쳐집니다. ` +
+      `${summary.artist}의 감동적인 무대를 놓치지 마세요. ` +
+      "이번 공연은 최고의 음향 시스템과 조명으로 관객 여러분께 " +
+      "잊지 못할 경험을 선사합니다.",
+    address: "서울특별시 서초구 남부순환로 2406",
+    duration: 120,
+    facilities: [
+      { icon: "🔊", label: "최신 음향 시스템" },
+      { icon: "🅿️", label: "주차 시설 (유료)" },
+      { icon: "🍽️", label: "푸드코트" },
+      { icon: "♿", label: "휠체어 접근 가능" },
+      { icon: "🚻", label: "수유실" },
+      { icon: "📶", label: "무료 Wi-Fi" },
+    ],
+    galleryUrls: [POSTER, POSTER, POSTER],
+    notices: [
+      "예매 후 취소/환불은 공연 7일 전까지만 가능합니다.",
+      "공연 당일 티켓과 신분증을 지참해주세요.",
+      "미성년자는 보호자 동반이 필요합니다.",
+    ],
+  };
+}
+
+export { mockDelay };

--- a/src/components/common/CircularTimer/CircularTimer.tsx
+++ b/src/components/common/CircularTimer/CircularTimer.tsx
@@ -1,0 +1,135 @@
+// src/components/common/CircularTimer/CircularTimer.tsx
+import { useMemo } from "react";
+
+interface CircularTimerProps {
+  /** 남은 시간 (초) */
+  remainingSeconds: number;
+  /** 전체 시간 (초) — 기본 300초(5분) */
+  totalSeconds?: number;
+  /** SVG 크기 (px) — 기본 280 */
+  size?: number;
+  /** 호 두께 (px) — 기본 18 */
+  strokeWidth?: number;
+}
+
+/**
+ * 좌석 임시 예약 카운트다운 타이머 (4개 호 디자인)
+ *
+ * ─ 운영 정책 ────────────────────────────────────────
+ * [카운트다운 및 프로그레스 바 로직]
+ *  - 프로그레스 바 동기화: 남은 시간에 비례하여 원형 프로그레스가 줄어듦
+ *  - 1분 미만: 빨간색(#C10007) 변경
+ *
+ * [디자인 가이드]
+ *  - 원형 프로그레스: 보라색(#6C5CE7), SVG 기반
+ *  - 카운트다운 텍스트: 큰 폰트, 1분 미만 시 빨간색
+ *  - "남은 시간" 텍스트 하단 배치
+ * ────────────────────────────────────────────────────
+ *
+ * ─ 디자인 ──────────────────────────────────────────
+ * 원이 4개의 호로 분할된 형태 (12·3·6·9시 방향에 호 중심).
+ * 진행률에 따라 보라색 호가 시계 방향으로 줄어들면서
+ * 뒤의 회색 호가 드러나는 구조.
+ * ────────────────────────────────────────────────────
+ *
+ * @example
+ * <CircularTimer remainingSeconds={298} />
+ *
+ * timerStore의 remainingMs와 함께 사용:
+ * const remainingMs = useTimerStore(s => s.remainingMs);
+ * <CircularTimer remainingSeconds={Math.ceil(remainingMs / 1000)} />
+ */
+export function CircularTimer({
+  remainingSeconds,
+  totalSeconds = 300,
+  size = 280,
+  strokeWidth = 18,
+}: CircularTimerProps) {
+  // 0 이하 또는 totalSeconds 초과 방어
+  const clampedRemaining = Math.max(
+    0,
+    Math.min(remainingSeconds, totalSeconds),
+  );
+
+  // SVG 기하 계산 (useMemo로 size/strokeWidth 변경 시에만 재계산)
+  const geometry = useMemo(() => {
+    const radius = (size - strokeWidth) / 2;
+    const circumference = 2 * Math.PI * radius;
+
+    // 4개 호로 분할: 호:갭 = 7:3
+    const SEGMENTS = 4;
+    const ARC_RATIO = 0.7;
+    const segmentLength = circumference / SEGMENTS;
+    const arcLength = segmentLength * ARC_RATIO;
+    const gapLength = segmentLength - arcLength;
+
+    return { radius, circumference, arcLength, gapLength };
+  }, [size, strokeWidth]);
+
+  // 진행률 — 남은 시간에 비례 (운영 정책: "타이머의 남은 시간과 비례")
+  const progress = clampedRemaining / totalSeconds;
+  const dashOffset = geometry.circumference * (1 - progress);
+
+  // 운영 정책: 1분 미만 빨간색 변경
+  const isWarning = clampedRemaining < 60;
+  const progressColor = isWarning ? "#C10007" : "#6C5CE7";
+
+  // 시간 포맷팅 (M:SS)
+  const minutes = Math.floor(clampedRemaining / 60);
+  const seconds = clampedRemaining % 60;
+  const timeText = `${minutes}:${seconds.toString().padStart(2, "0")}`;
+
+  const center = size / 2;
+  const dashArray = `${geometry.arcLength} ${geometry.gapLength}`;
+
+  return (
+    <div className="relative inline-flex flex-col items-center justify-center">
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        role="img"
+        aria-label={`남은 시간 ${minutes}분 ${seconds}초`}
+      >
+        {/* 배경 — 회색 4개 호 (항상 표시) */}
+        <circle
+          cx={center}
+          cy={center}
+          r={geometry.radius}
+          fill="none"
+          stroke="#E5E7EB"
+          strokeWidth={strokeWidth}
+          strokeDasharray={dashArray}
+          strokeLinecap="round"
+          transform={`rotate(-90 ${center} ${center})`}
+        />
+        {/* 진행 — 보라색 호 (시간 지나면서 줄어듦) */}
+        <circle
+          cx={center}
+          cy={center}
+          r={geometry.radius}
+          fill="none"
+          stroke={progressColor}
+          strokeWidth={strokeWidth}
+          strokeDasharray={dashArray}
+          strokeDashoffset={dashOffset}
+          strokeLinecap="round"
+          transform={`rotate(-90 ${center} ${center})`}
+          className="transition-[stroke-dashoffset,stroke] duration-1000 ease-linear"
+        />
+      </svg>
+
+      {/* 중앙 텍스트 — SVG 위에 absolute 배치 */}
+      <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+        <span
+          className={`text-5xl font-bold tabular-nums leading-none ${
+            isWarning ? "text-[#C10007]" : "text-primary"
+          }`}
+        >
+          {timeText}
+        </span>
+        <span className="mt-3 text-sm text-gray-500">남은 시간</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/concert/BannerSlider.tsx
+++ b/src/components/concert/BannerSlider.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Calendar } from "lucide-react";
+import { useBanners } from "@/hooks/queries/useBanners";
+
+const AUTO_SLIDE_INTERVAL = 4000;
+
+// 슬라이드별 배경 그라데이션 (id 기준 순환)
+const GRADIENTS = [
+  "from-purple-500 to-indigo-600",
+  "from-pink-500 to-purple-600",
+  "from-blue-500 to-cyan-600",
+];
+
+export default function BannerSlider() {
+  const navigate = useNavigate();
+  const { data: banners, isLoading } = useBanners();
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+
+  const totalSlides = banners?.length ?? 0;
+
+  // 자동 슬라이드 + hover pause
+  useEffect(() => {
+    if (isPaused || totalSlides <= 1) return;
+    const interval = setInterval(() => {
+      setCurrentIndex((p) => (p + 1) % totalSlides);
+    }, AUTO_SLIDE_INTERVAL);
+    return () => clearInterval(interval);
+  }, [isPaused, totalSlides]);
+
+  // 슬라이드 수가 바뀌었을 때 인덱스 초과 방지
+  useEffect(() => {
+    if (currentIndex >= totalSlides && totalSlides > 0) {
+      setCurrentIndex(0);
+    }
+  }, [currentIndex, totalSlides]);
+
+  if (isLoading) {
+    return (
+      <div className="w-full h-48 bg-gray-100 rounded-2xl animate-pulse" />
+    );
+  }
+
+  if (!banners || banners.length === 0) {
+    return null;
+  }
+
+  const current = banners[currentIndex];
+  const gradient = GRADIENTS[currentIndex % GRADIENTS.length];
+  const isClickable = !!current.linkConcertId;
+
+  return (
+    <div
+      className="relative w-full"
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+    >
+      <div
+        className={`bg-gradient-to-r ${gradient} rounded-2xl p-8 overflow-hidden relative transition-all duration-500 ${
+          isClickable ? "cursor-pointer" : ""
+        }`}
+        onClick={() => {
+          if (current.linkConcertId) {
+            navigate(`/concerts/${current.linkConcertId}`);
+          }
+        }}
+        role={isClickable ? "button" : undefined}
+        tabIndex={isClickable ? 0 : -1}
+      >
+        {/* 컨텐츠 */}
+        <div className="relative z-10 text-white max-w-2xl">
+          {current.tagLabel && (
+            <span className="inline-block px-3 py-1 rounded-full text-xs font-semibold bg-white/20 backdrop-blur mb-3">
+              {current.tagLabel}
+            </span>
+          )}
+          <h2 className="text-3xl font-bold mb-1">
+            {current.iconEmoji && (
+              <span className="mr-2">{current.iconEmoji}</span>
+            )}
+            {current.title}
+          </h2>
+          {current.subtitle && (
+            <p className="text-lg mb-2 font-semibold">{current.subtitle}</p>
+          )}
+          {current.description && (
+            <p className="text-sm opacity-90 mb-3">{current.description}</p>
+          )}
+          {current.date && (
+            <div className="flex items-center gap-1.5 text-sm">
+              <Calendar size={14} />
+              <span>{current.date}</span>
+            </div>
+          )}
+        </div>
+
+        {/* 우측 워터마크 이모지 */}
+        {current.iconEmoji && (
+          <div
+            className="absolute right-12 top-1/2 -translate-y-1/2 text-white/15 text-9xl pointer-events-none select-none"
+            aria-hidden="true"
+          >
+            {current.iconEmoji}
+          </div>
+        )}
+      </div>
+
+      {/* 인디케이터 도트 */}
+      {banners.length > 1 && (
+        <div className="flex justify-center gap-2 mt-4">
+          {banners.map((_, idx) => (
+            <button
+              key={idx}
+              type="button"
+              onClick={() => setCurrentIndex(idx)}
+              className={`h-2 rounded-full transition-all ${
+                idx === currentIndex
+                  ? "w-6 bg-primary"
+                  : "w-2 bg-gray-300 hover:bg-gray-400"
+              }`}
+              aria-label={`슬라이드 ${idx + 1}로 이동`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/concert/BookingSidebar.tsx
+++ b/src/components/concert/BookingSidebar.tsx
@@ -1,0 +1,114 @@
+// 공연 상세 페이지 우측 sticky 사이드바
+import { Ticket, AlertTriangle } from "lucide-react";
+import type { ConcertStatus } from "@/types/domain/concert";
+
+interface BookingSidebarProps {
+  remaining: number;
+  total: number;
+  price: number;
+  duration: number;
+  isOnSale: boolean;
+  status: ConcertStatus;
+  notices: string[];
+  onBooking: () => void;
+}
+
+export default function BookingSidebar({
+  remaining,
+  total,
+  price,
+  duration,
+  isOnSale,
+  status,
+  notices,
+  onBooking,
+}: BookingSidebarProps) {
+  const percent = total > 0 ? (remaining / total) * 100 : 0;
+  const isSoldOut = status === "SOLD_OUT" || remaining === 0;
+
+  const buttonLabel = isOnSale ? "예매하기" : isSoldOut ? "매진" : "예매 종료";
+
+  return (
+    <div className="lg:sticky lg:top-4 space-y-3">
+      {/* 메인 박스 */}
+      <div className="bg-white border border-border rounded-xl p-5 space-y-4">
+        <h3 className="font-bold">예매 정보</h3>
+
+        {/* 잔여 좌석 + 게이지바 */}
+        <div>
+          <div className="flex items-baseline justify-between mb-2">
+            <span className="text-xs text-text-secondary">잔여 좌석</span>
+            <div className="flex items-baseline gap-0.5">
+              <span className="text-3xl font-bold text-text">{remaining}</span>
+              <span className="text-xs text-text-secondary">/{total}</span>
+            </div>
+          </div>
+          <div className="w-full h-1 bg-gray-100 rounded-full overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all ${
+                isSoldOut ? "bg-danger" : "bg-primary"
+              }`}
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+          <p className="text-[10px] text-text-secondary mt-1">
+            {Math.round(percent)}% 잔여
+          </p>
+        </div>
+
+        {/* 1인 가격 — 강조 박스 */}
+        <div className="border-2 border-primary rounded-lg p-3 bg-primary/5">
+          <p className="text-xs text-text-secondary">1인 가격</p>
+          <p className="text-2xl font-bold text-primary mt-0.5">
+            ₩{price.toLocaleString()}
+          </p>
+        </div>
+
+        {/* 관람 시간 박스 */}
+        <div className="bg-gray-50 rounded-lg p-3 flex items-center justify-between">
+          <span className="text-xs text-text-secondary">관람 시간</span>
+          <span className="text-sm font-semibold">{duration}분</span>
+        </div>
+
+        {/* 예매 버튼 */}
+        <button
+          type="button"
+          onClick={onBooking}
+          disabled={!isOnSale}
+          className={`w-full py-3 rounded-lg font-bold flex items-center justify-center gap-2 transition-colors ${
+            isOnSale
+              ? "bg-primary text-white hover:opacity-90"
+              : "bg-gray-200 text-gray-400 cursor-not-allowed"
+          }`}
+        >
+          <Ticket size={16} />
+          {buttonLabel}
+        </button>
+
+        {/* 노란 경고 박스 */}
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 flex items-start gap-2">
+          <AlertTriangle
+            size={14}
+            className="text-yellow-700 mt-0.5 shrink-0"
+          />
+          <p className="text-xs text-yellow-800 leading-relaxed">
+            <span className="font-bold">예매 시 주의:</span> 좌석 선택 후 5분의
+            제한 시간이 적용됩니다.
+          </p>
+        </div>
+      </div>
+
+      {/* 유의사항 박스 */}
+      <div className="bg-white border border-border rounded-xl p-4">
+        <ul className="text-xs text-text-secondary space-y-1.5">
+          {notices.map((n, i) => (
+            <li key={i} className="flex items-start gap-1.5">
+              <span className="text-primary shrink-0">•</span>
+              <span className="leading-relaxed">{n}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/concert/ConcertCard.tsx
+++ b/src/components/concert/ConcertCard.tsx
@@ -1,0 +1,123 @@
+import { memo } from "react";
+import { useNavigate } from "react-router-dom";
+import { MapPin, Calendar } from "lucide-react";
+import type { ConcertSummary } from "../../api/types/domain/concert";
+import GenreBadge from "./GenreBadge";
+import SeatGauge from "./SeatGauge";
+import samplePoster from "@/assets/images/sample-poster.svg";
+
+interface ConcertCardProps {
+  concert: ConcertSummary;
+}
+
+function ConcertCard({ concert }: ConcertCardProps) {
+  const navigate = useNavigate();
+  const isSoldOut =
+    concert.status === "SOLD_OUT" || concert.remainingSeats === 0;
+  const remainingPercent =
+    concert.totalSeats > 0
+      ? (concert.remainingSeats / concert.totalSeats) * 100
+      : 0;
+  const isEndingSoon = !isSoldOut && remainingPercent <= 20;
+
+  const formattedPrice = concert.price.toLocaleString("ko-KR");
+
+  const d = new Date(concert.date);
+  const formattedDate = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+  function handleClick() {
+    if (!isSoldOut) navigate(`/concerts/${concert.id}`);
+  }
+
+  return (
+    <article
+      className={`group rounded-xl overflow-hidden border border-gray-100 bg-white shadow-sm hover:shadow-md transition-shadow duration-200 ${
+        isSoldOut ? "" : "cursor-pointer"
+      }`}
+      onClick={handleClick}
+      role="link"
+      tabIndex={isSoldOut ? -1 : 0}
+      onKeyDown={(e) => {
+        if (!isSoldOut && (e.key === "Enter" || e.key === " ")) {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+    >
+      <div className="relative aspect-[4/3] overflow-hidden bg-gray-100">
+        <img
+          src={concert.posterUrl || samplePoster}
+          alt={`${concert.title} 포스터`}
+          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+          loading="lazy"
+          onError={(e) => {
+            (e.target as HTMLImageElement).src = samplePoster;
+          }}
+        />
+
+        {/* 마감임박 뱃지 (우상단) */}
+        {isEndingSoon && (
+          <div className="absolute top-2 right-2">
+            <span className="inline-block px-2 py-1 rounded-md text-[10px] font-bold bg-red-100 text-red-600">
+              마감임박
+            </span>
+          </div>
+        )}
+
+        {/* 장르 뱃지 (좌하단) */}
+        <div className="absolute bottom-2 left-2">
+          <GenreBadge genre={concert.genre} />
+        </div>
+      </div>
+
+      <div className="p-4 space-y-2">
+        <h3 className="text-sm font-bold text-gray-900 line-clamp-2 leading-snug min-h-[2.5rem]">
+          {concert.title}
+        </h3>
+        <p className="text-xs text-gray-500 truncate">{concert.artist}</p>
+
+        <div className="space-y-1 text-xs text-gray-600">
+          <p className="flex items-center gap-1.5 truncate">
+            <MapPin size={14} className="shrink-0 text-gray-400" />
+            <span className="truncate">{concert.venue}</span>
+          </p>
+          <p className="flex items-center gap-1.5">
+            <Calendar size={14} className="shrink-0 text-gray-400" />
+            <span>
+              {formattedDate} {concert.time}
+            </span>
+          </p>
+        </div>
+
+        {/* 가격 (라벨 좌측, 금액 우측) */}
+        <div className="flex items-baseline justify-between pt-1">
+          <span className="text-xs text-gray-500">가격</span>
+          <p className="text-base font-bold text-primary">₩{formattedPrice}</p>
+        </div>
+
+        <SeatGauge
+          remaining={concert.remainingSeats}
+          total={concert.totalSeats}
+        />
+
+        <button
+          type="button"
+          className={`w-full py-2 rounded-lg text-sm font-semibold transition-colors ${
+            isSoldOut
+              ? "bg-gray-200 text-gray-400 cursor-not-allowed"
+              : "bg-primary text-white hover:opacity-90"
+          }`}
+          disabled={isSoldOut}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (!isSoldOut) handleClick();
+          }}
+        >
+          {isSoldOut ? "예매불가" : "예매하기"}
+        </button>
+      </div>
+    </article>
+  );
+}
+
+export default memo(ConcertCard);

--- a/src/components/concert/ConcertCardSkeleton.tsx
+++ b/src/components/concert/ConcertCardSkeleton.tsx
@@ -1,0 +1,27 @@
+import Skeleton from "../common/Skeleton/Skeleton";
+
+/** 공연 카드 로딩 스켈레톤 — ConcertCard와 동일한 레이아웃 */
+export default function ConcertCardSkeleton() {
+  return (
+    <div className="rounded-xl overflow-hidden border border-gray-100 bg-white shadow-sm">
+      {/* 포스터 영역 (4:3) */}
+      <div className="aspect-[4/3] bg-gray-200 animate-pulse" />
+
+      {/* 카드 내용 */}
+      <div className="p-4 space-y-2">
+        <Skeleton variant="text" width="80%" height="1rem" />
+        <Skeleton variant="text" width="50%" height="0.75rem" />
+        <Skeleton variant="text" width="70%" height="0.75rem" />
+        <Skeleton variant="text" width="60%" height="0.75rem" />
+        <Skeleton variant="text" width="30%" height="1rem" />
+        <Skeleton variant="text" width="100%" height="4px" />
+        <Skeleton
+          variant="text"
+          width="100%"
+          height="2.25rem"
+          className="rounded-lg"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/concert/GenreBadge.tsx
+++ b/src/components/concert/GenreBadge.tsx
@@ -1,0 +1,47 @@
+import type { Genre } from "../../api/types/domain/concert";
+
+interface GenreBadgeProps {
+  genre: Genre;
+  className?: string;
+}
+
+// Genre 타입의 키값에 맞게 조정 (MUSICAL, CONCERT 등 실제 키값 확인 필요)
+const genreStyles: Record<Genre, { label: string; classes: string }> = {
+  MUSICAL: {
+    label: "뮤지컬",
+    classes: "bg-genre-musical/[0.125] text-genre-musical",
+  },
+  CONCERT: {
+    label: "콘서트",
+    classes: "bg-genre-concert/[0.125] text-genre-concert",
+  },
+  CLASSIC: {
+    label: "클래식",
+    classes: "bg-genre-classic/[0.125] text-genre-classic",
+  },
+  JAZZ: { label: "재즈", classes: "bg-genre-jazz/[0.125] text-genre-jazz" },
+  FESTIVAL: {
+    label: "페스티벌",
+    classes: "bg-genre-festival/[0.125] text-genre-festival",
+  },
+  FANMEETING: {
+    label: "팬미팅",
+    classes: "bg-genre-fanmeeting/[0.125] text-genre-fanmeeting",
+  },
+  BALLET: {
+    label: "발레",
+    classes: "bg-genre-ballet/[0.125] text-genre-ballet",
+  },
+};
+
+export default function GenreBadge({ genre, className = "" }: GenreBadgeProps) {
+  const { label, classes } = genreStyles[genre];
+
+  return (
+    <span
+      className={`inline-block px-2.5 py-1 text-xs font-semibold rounded-md ${classes} ${className}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/components/concert/SeatGauge.tsx
+++ b/src/components/concert/SeatGauge.tsx
@@ -1,0 +1,41 @@
+interface SeatGaugeProps {
+  remaining: number;
+  total: number;
+}
+
+export default function SeatGauge({ remaining, total }: SeatGaugeProps) {
+  const percent = total > 0 ? Math.round((remaining / total) * 100) : 0;
+  const isSoldOut = remaining === 0;
+  // 마감임박 = 잔여 20% 이하 (단, 매진 제외)
+  const isEndingSoon = !isSoldOut && percent <= 20;
+
+  const barColor = isSoldOut || isEndingSoon ? "bg-danger" : "bg-primary";
+
+  return (
+    <div className="w-full">
+      <div className="flex justify-between items-baseline mb-1.5">
+        <span className="text-xs text-placeholder">잔여 좌석</span>
+        <span
+          className={`text-sm font-bold ${
+            isSoldOut ? "text-danger" : "text-text"
+          }`}
+        >
+          {remaining}석
+        </span>
+      </div>
+      <div
+        className="w-full h-1 bg-gray-100 rounded-full overflow-hidden"
+        role="progressbar"
+        aria-valuenow={percent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`잔여 좌석 ${remaining}/${total}`}
+      >
+        <div
+          className={`h-full ${barColor} rounded-full transition-all duration-300`}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/constants/genre.ts
+++ b/src/constants/genre.ts
@@ -1,0 +1,16 @@
+import type { Genre } from "../api/types/domain/concert";
+
+interface GenreConfig {
+  label: string;
+  color: string;
+}
+
+export const GENRE_MAP: Record<Genre, GenreConfig> = {
+  MUSICAL: { label: "뮤지컬", color: "#6C5CE7" },
+  CONCERT: { label: "콘서트", color: "#FF6B9D" },
+  CLASSIC: { label: "클래식", color: "#6496FF" },
+  JAZZ: { label: "재즈", color: "#FFA502" },
+  FESTIVAL: { label: "페스티벌", color: "#20AE7F" },
+  FANMEETING: { label: "팬미팅", color: "#E679FF" },
+  BALLET: { label: "발레", color: "#C6B5FF" },
+} as const;

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,0 +1,48 @@
+// React Query 캐시 키 중앙 관리
+// 규칙: ["도메인", "구분", ...파라미터]
+//
+// 사용 예:
+//   queryClient.invalidateQueries({ queryKey: queryKeys.concerts.all })
+//   queryClient.invalidateQueries({ queryKey: queryKeys.concerts.detail(1) })
+
+import type { ConcertListParams } from "@/types/domain/concert";
+import type { MyBookingsParams } from "@/types/domain/booking";
+
+export const queryKeys = {
+  auth: {
+    all: ["auth"] as const,
+    me: () => ["auth", "me"] as const,
+    oauthUrl: (provider: string) => ["auth", "oauth-url", provider] as const,
+  },
+  concerts: {
+    all: ["concerts"] as const,
+    list: (params?: ConcertListParams) =>
+      ["concerts", "list", params] as const,
+    detail: (id: number) => ["concerts", "detail", id] as const,
+  },
+  seats: {
+    all: ["seats"] as const,
+    /** 좌석 배치 + 상태 통합 조회 */
+    byPerformance: (performanceId: number) =>
+      ["seats", "byPerformance", performanceId] as const,
+    /** 좌석 잔여 수 */
+    counts: (performanceId: number) =>
+      ["seats", "counts", performanceId] as const,
+  },
+  bookings: {
+    all: ["bookings"] as const,
+    mine: (params?: MyBookingsParams) =>
+      ["bookings", "mine", params] as const,
+    detail: (bookingNumber: string) =>
+      ["bookings", "detail", bookingNumber] as const,
+  },
+  payments: {
+    all: ["payments"] as const,
+    status: (paymentKey: string) =>
+      ["payments", "status", paymentKey] as const,
+  },
+} as const;
+
+// 호환성용 - 기존 imports
+export type { ConcertListParams, MyBookingsParams };
+export default queryKeys;

--- a/src/hooks/queries/useBanners.ts
+++ b/src/hooks/queries/useBanners.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchBanners } from "@/api/banners";
+
+const bannerKeys = {
+  all: ["banners"] as const,
+  list: () => ["banners", "list"] as const,
+};
+
+export function useBanners() {
+  return useQuery({
+    queryKey: bannerKeys.list(),
+    queryFn: fetchBanners,
+    staleTime: 5 * 60 * 1000, // 5분
+  });
+}

--- a/src/hooks/queries/useConcerts.ts
+++ b/src/hooks/queries/useConcerts.ts
@@ -1,0 +1,19 @@
+// 공연 목록 — cursor 기반 infinite scroll
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchConcerts } from "@/api/concerts";
+import { queryKeys } from "@/constants/queryKeys";
+import type { ConcertListParams } from "@/types/domain/concert";
+
+export function useConcerts(params: Omit<ConcertListParams, "cursor"> = {}) {
+  return useInfiniteQuery({
+    queryKey: queryKeys.concerts.list(params),
+    queryFn: ({ pageParam }) =>
+      fetchConcerts({ ...params, cursor: pageParam }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) =>
+      lastPage.pagination.hasNext
+        ? lastPage.pagination.nextCursor
+        : undefined,
+    staleTime: 60_000,
+  });
+}

--- a/src/pages/Concert/ConcertListPage.tsx
+++ b/src/pages/Concert/ConcertListPage.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from "react";
+import { useConcerts } from "@/hooks/queries/useConcerts";
+import ConcertCard from "@/components/concert/ConcertCard";
+import ConcertCardSkeleton from "@/components/concert/ConcertCardSkeleton";
+import BannerSlider from "@/components/concert/BannerSlider";
+
+export default function ConcertListPage() {
+  const {
+    data,
+    isLoading,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useConcerts({ size: 8 });
+
+  // 무한 스크롤
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel || !hasNextPage) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const concerts = data?.pages.flatMap((p) => p.items) ?? [];
+
+  return (
+    <div className="max-w-7xl mx-auto px-6 py-8 space-y-8">
+      {/* 제목 */}
+      <div>
+        <h1 className="text-3xl font-bold text-text">공연 목록</h1>
+        <p className="text-sm text-text-secondary mt-1">
+          예매 가능한 공연을 선택하세요
+        </p>
+      </div>
+
+      {/* 카드 그리드 */}
+      {isError ? (
+        <div className="bg-white border border-border rounded-xl p-12 text-center text-error">
+          공연 목록을 불러올 수 없습니다.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+          {isLoading
+            ? Array.from({ length: 8 }).map((_, i) => (
+                <ConcertCardSkeleton key={i} />
+              ))
+            : concerts.map((c) => <ConcertCard key={c.id} concert={c} />)}
+        </div>
+      )}
+
+      {!isLoading && concerts.length === 0 && !isError && (
+        <div className="text-center text-text-secondary py-12">
+          등록된 공연이 없습니다.
+        </div>
+      )}
+
+      {/* 배너 슬라이더 */}
+      <BannerSlider />
+
+      {/* 무한 스크롤 trigger */}
+      <div ref={sentinelRef} className="h-1" />
+      {isFetchingNextPage && (
+        <div className="text-center text-text-secondary py-4 text-xs">
+          더 불러오는 중...
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/stores/reservation/timerStore.ts
+++ b/src/stores/reservation/timerStore.ts
@@ -1,0 +1,114 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { useEffect } from "react";
+
+type TimerStatus = "idle" | "running" | "expired";
+
+interface TimerState {
+  status: TimerStatus;
+  remainingMs: number;
+  durationMs: number;
+
+  /** 타이머 시작 (default 5분) */
+  startTimer: (durationMs?: number) => void;
+  /** 타이머 정지 (정상 종료 — 결제 성공 시) */
+  stopTimer: () => void;
+  /** 모든 상태 초기화 */
+  reset: () => void;
+}
+
+const DEFAULT_DURATION_MS = 5 * 60 * 1000;
+
+// 모듈 스코프 — store 외부에 interval ID 보관 (state에 넣으면 비교 리렌더 발생)
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+function clearTimerInterval() {
+  if (intervalId !== null) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+export const useTimerStore = create<TimerState>()(
+  devtools(
+    (set) => ({
+      status: "idle",
+      remainingMs: 0,
+      durationMs: DEFAULT_DURATION_MS,
+
+      startTimer: (durationMs = DEFAULT_DURATION_MS) => {
+        clearTimerInterval();
+        const endsAt = Date.now() + durationMs;
+
+        set({ status: "running", durationMs, remainingMs: durationMs });
+
+        // 250ms 간격으로 갱신 — CircularTimer가 부드럽게 줄어들도록
+        intervalId = setInterval(() => {
+          const remaining = Math.max(0, endsAt - Date.now());
+
+          if (remaining <= 0) {
+            clearTimerInterval();
+            set({ status: "expired", remainingMs: 0 });
+          } else {
+            set({ remainingMs: remaining });
+          }
+        }, 250);
+      },
+
+      stopTimer: () => {
+        clearTimerInterval();
+        set({ status: "idle", remainingMs: 0 });
+      },
+
+      reset: () => {
+        clearTimerInterval();
+        set({
+          status: "idle",
+          remainingMs: 0,
+          durationMs: DEFAULT_DURATION_MS,
+        });
+      },
+    }),
+    { name: "TimerStore" },
+  ),
+);
+
+// ─────────────────────────────────────────────────────────
+// Convenience hooks
+// ─────────────────────────────────────────────────────────
+
+/**
+ * 타이머가 expired 상태로 전이되는 순간을 감지하여 콜백 실행.
+ * - status가 'expired'로 바뀌는 순간 한 번만 호출됨
+ * - 콜백 안에서 reset() 호출하면 다음 진입 시 중복 실행 방지
+ *
+ * @example
+ *   useTimerExpiry(() => {
+ *     paymentStore.expire();
+ *     navigate("/payment/expired");
+ *   });
+ */
+export function useTimerExpiry(onExpire: () => void) {
+  const status = useTimerStore((s) => s.status);
+  useEffect(() => {
+    if (status === "expired") onExpire();
+    // onExpire는 매 렌더마다 새 함수일 수 있어 의존성에서 제외 (필요 시 useCallback)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status]);
+}
+
+/** 남은 시간을 mm:ss 포맷으로 (CircularTimer 등에서 사용) */
+export function useTimerDisplay() {
+  const remainingMs = useTimerStore((s) => s.remainingMs);
+  const durationMs = useTimerStore((s) => s.durationMs);
+
+  const totalSec = Math.ceil(remainingMs / 1000);
+  const mm = Math.floor(totalSec / 60);
+  const ss = totalSec % 60;
+  const formatted = `${String(mm).padStart(2, "0")}:${String(ss).padStart(2, "0")}`;
+  const progress = durationMs > 0 ? remainingMs / durationMs : 0;
+
+  return { mm, ss, formatted, remainingMs, progress };
+}
+
+export default useTimerStore;

--- a/src/types/domain/banner.ts
+++ b/src/types/domain/banner.ts
@@ -1,0 +1,15 @@
+export interface BannerItem {
+  id: number;
+  title: string;
+  subtitle?: string;
+  description?: string;
+  /** 좌상단 작은 태그 ("조기 예매 할인" 등) */
+  tagLabel?: string;
+  /** 제목 앞 + 우측 큰 워터마크 이모지 */
+  iconEmoji?: string;
+  date?: string;
+  /** 배너 클릭 시 이동할 공연 ID (없으면 클릭 비활성) */
+  linkConcertId?: number;
+  /** 슬라이드 순서 */
+  order: number;
+}

--- a/src/types/domain/concert.ts
+++ b/src/types/domain/concert.ts
@@ -1,0 +1,67 @@
+// 공연 도메인 타입
+// 가상 스펙 — 백엔드 performance-service swagger 확정 시 정렬 필요
+
+export type Genre =
+  | "CONCERT"
+  | "MUSICAL"
+  | "CLASSIC"
+  | "JAZZ"
+  | "FESTIVAL"
+  | "FANMEETING"
+  | "BALLET";
+
+export type ConcertStatus = "ON_SALE" | "SOLD_OUT" | "ENDED" | "UPCOMING";
+
+export type ConcertSort = "LATEST" | "POPULAR" | "PRICE_ASC" | "PRICE_DESC";
+
+export interface ConcertSummary {
+  id: number;
+  title: string;
+  artist: string;
+  genre: Genre;
+  venue: string;
+  /** ISO date: "YYYY-MM-DD" */
+  date: string;
+  /** "HH:mm" */
+  time: string;
+  price: number;
+  posterUrl: string;
+  totalSeats: number;
+  remainingSeats: number;
+  status: ConcertStatus;
+}
+
+export interface ConcertFacility {
+  icon: string;
+  label: string;
+}
+
+export interface ConcertDetail extends ConcertSummary {
+  description: string;
+  address: string;
+  /** minutes */
+  duration: number;
+  facilities: ConcertFacility[];
+  galleryUrls: string[];
+  notices: string[];
+}
+
+export interface ConcertListParams {
+  cursor?: number;
+  size?: number;
+  genre?: Genre;
+  sort?: ConcertSort;
+  status?: ConcertStatus;
+  minPrice?: number;
+  maxPrice?: number;
+  keyword?: string;
+}
+
+export interface ConcertListResponse {
+  items: ConcertSummary[];
+  pagination: {
+    hasNext: boolean;
+    nextCursor: number;
+    size: number;
+  };
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #25
- close #26
- close #28

---

## 📌 주요 변경 사항

- 공연 카드 (ConcertCard) + 메인 그리드 레이아웃 (ConcertListPage) 구현
- BannerSlider 구현 (자동 슬라이드 + hover pause)
- BookingSidebar 구현 (잔여 좌석 게이지 + 예매 프로세스 안내)

---

## 🛠 상세 구현 내용

### 공연 카드 + 그리드 (#25)
- `components/concert/ConcertCard.tsx` - 4:3 포스터 + 가격 + 마감임박 뱃지
- `components/concert/ConcertCardSkeleton.tsx` - 로딩 상태
- `components/concert/SeatGauge.tsx` - 잔여 좌석 게이지 ("245석" 단일 표시)
- `components/concert/GenreBadge.tsx` - 장르별 색상 매핑
- `pages/Concert/ConcertListPage.tsx` - 메인 그리드 (max-w-7xl)
- `hooks/queries/useConcerts.ts` - useInfiniteQuery 기반 cursor 페이징
- `api/concerts.ts`, `api/mocks/concerts.ts`
- `types/domain/concert.ts`, `constants/genre.ts`

### 배너 슬라이더 (#26)
- `components/concert/BannerSlider.tsx`
- 4초 자동 슬라이드 + hover 시 일시정지
- `hooks/queries/useBanners.ts`, `api/banners.ts`, mock 데이터 3개
- `types/domain/banner.ts`

### BookingSidebar (#28)
- `components/concert/BookingSidebar.tsx`
- 잔여좌석 + 게이지 표시
- 1인 가격 강조 박스
- 관람 시간 + 예매 버튼 + 노란 경고 + 유의사항

---

## ✅ 테스트

### 테스트 방법
- `/concerts` 접속 → 카드 그리드 + 배너 자동 슬라이드 동작 확인
- 잔여 좌석 20% 이하 카드 → "마감임박" 뱃지 노출
- 매진 카드 → "예매불가" 상태 표시
- 공연 상세 진입 → BookingSidebar 표시

### 테스트 결과
- [x] 배너 4초 자동 슬라이드 + hover pause
- [x] 마감임박/예매불가 뱃지 분기
- [x] 무한 스크롤 정상 동작
- [x] `npx tsc --noEmit` 통과

---

## 👀 리뷰 요청 사항

- 검색/필터 UI는 피그마 부재로 의도적으로 제외 (목록 깔끔 우선)
- 배너 mock 3건 → 백엔드 `/api/v1/banners` 엔드포인트 신설 필요

---

## ⚠️ 배포 시 주의사항

- 배너 API 엔드포인트 백엔드 협의 필요
- 공연 목록 응답에 `remainingSeats`, `totalSeats` 필드 필요 (게이지 계산용)