### PR TITLE
[Feat] #78 3D 캐릭터 피부색 팔레트 확장 및 재질 적용

### DIFF
--- a/src/components/admin/character/characterSkin.ts
+++ b/src/components/admin/character/characterSkin.ts
@@ -1,0 +1,119 @@
+export type SkinTonePreset =
+  | "light"
+  | "lightMedium"
+  | "medium"
+  | "tan"
+  | "dark";
+
+export type SkinToneSelection = SkinTonePreset | "custom";
+
+export interface SkinTonePresetOption {
+  value: SkinTonePreset;
+  label: string;
+  color: string;
+}
+
+export interface ResolvedSkinTone {
+  skinTone: SkinToneSelection;
+  skinColor: string;
+}
+
+export const SKIN_TONE_PRESETS: SkinTonePresetOption[] = [
+  { value: "light", label: "Light", color: "#F7C6A8" },
+  {
+    value: "lightMedium",
+    label: "Light Medium",
+    color: "#E8B08F",
+  },
+  { value: "medium", label: "Medium", color: "#D59A78" },
+  { value: "tan", label: "Tan", color: "#BF7D4F" },
+  { value: "dark", label: "Dark", color: "#8F582D" },
+];
+
+export const DEFAULT_SKIN_TONE: SkinTonePreset = "light";
+export const DEFAULT_SKIN_COLOR = "#F7C6A8";
+
+const HEX_COLOR_PATTERN = /^#?[0-9A-Fa-f]{6}$/;
+const SKIN_TONE_PRESET_VALUES = new Set<SkinTonePreset>(
+  SKIN_TONE_PRESETS.map((preset) => preset.value),
+);
+
+export function normalizeHexColor(value: string): string | null {
+  const trimmed = value.trim();
+
+  if (!HEX_COLOR_PATTERN.test(trimmed)) {
+    return null;
+  }
+
+  const normalized = trimmed.startsWith("#")
+    ? trimmed
+    : `#${trimmed}`;
+
+  return normalized.toUpperCase();
+}
+
+export function isSkinTonePreset(value: unknown): value is SkinTonePreset {
+  return (
+    typeof value === "string" &&
+    SKIN_TONE_PRESET_VALUES.has(value as SkinTonePreset)
+  );
+}
+
+export function findSkinTonePresetByColor(
+  color: string,
+): SkinTonePreset | undefined {
+  const normalized = normalizeHexColor(color);
+
+  if (!normalized) {
+    return undefined;
+  }
+
+  return SKIN_TONE_PRESETS.find(
+    (preset) => preset.color.toUpperCase() === normalized,
+  )?.value;
+}
+
+export function getSkinTonePresetColor(
+  preset: SkinTonePreset,
+): string {
+  return (
+    SKIN_TONE_PRESETS.find((option) => option.value === preset)?.color ??
+    DEFAULT_SKIN_COLOR
+  );
+}
+
+export function resolveStoredSkinTone(
+  skinTone: unknown,
+  skinColor: unknown,
+): ResolvedSkinTone {
+  const normalizedColor =
+    typeof skinColor === "string" ? normalizeHexColor(skinColor) : null;
+
+  if (skinTone === "custom" && normalizedColor) {
+    return {
+      skinTone: "custom",
+      skinColor: normalizedColor,
+    };
+  }
+
+  if (isSkinTonePreset(skinTone)) {
+    return {
+      skinTone,
+      skinColor: normalizedColor ?? getSkinTonePresetColor(skinTone),
+    };
+  }
+
+  if (normalizedColor) {
+    const matchedPreset = findSkinTonePresetByColor(normalizedColor);
+
+    return {
+      skinTone: matchedPreset ?? "custom",
+      skinColor: normalizedColor,
+    };
+  }
+
+  return {
+    skinTone: DEFAULT_SKIN_TONE,
+    skinColor: DEFAULT_SKIN_COLOR,
+  };
+}

--- a/src/pages/Admin/AdminCharacterCreatorPage.tsx
+++ b/src/pages/Admin/AdminCharacterCreatorPage.tsx
@@ -1,13 +1,21 @@
 import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import CharacterModelViewer from "@/components/admin/character/CharacterModelViewer";
-
-type SkinTone = "light" | "medium" | "tan" | "dark";
+import {
+  DEFAULT_SKIN_COLOR,
+  DEFAULT_SKIN_TONE,
+  SKIN_TONE_PRESETS,
+  findSkinTonePresetByColor,
+  normalizeHexColor,
+  resolveStoredSkinTone,
+  type SkinToneSelection,
+} from "@/components/admin/character/characterSkin";
 type HairStyle = "short" | "long" | "bun" | "ponytail" | "wave" | "rainbow";
 type Pose = "standing" | "wave" | "heart" | "dance" | "sing";
 
 interface CharacterConfig {
-  skinTone: SkinTone;
+  skinTone: SkinToneSelection;
+  skinColor: string;
   hairStyle: HairStyle;
   hairColor: string;
   outfitName: string;
@@ -25,15 +33,6 @@ interface BackgroundPreset {
 }
 
 const CHARACTER_STORAGE_KEY = "ticketRush:admin-character";
-const HEX_COLOR_PATTERN = /^#?[0-9A-Fa-f]{6}$/;
-
-const SKIN_TONES: { value: SkinTone; label: string; color: string }[] = [
-  { value: "light", label: "Light", color: "#f7c6a8" },
-  { value: "medium", label: "Medium", color: "#d9a78c" },
-  { value: "tan", label: "Tan", color: "#bf7f54" },
-  { value: "dark", label: "Dark", color: "#8b5a2b" },
-];
-
 const HAIR_STYLES: { value: HairStyle; label: string; icon: string }[] = [
   { value: "short", label: "숏컷", icon: "👱" },
   { value: "long", label: "단발", icon: "👩" },
@@ -121,7 +120,8 @@ const BACKGROUNDS: BackgroundPreset[] = [
 ];
 
 const DEFAULT_CHARACTER: CharacterConfig = {
-  skinTone: "light",
+  skinTone: DEFAULT_SKIN_TONE,
+  skinColor: DEFAULT_SKIN_COLOR,
   hairStyle: "ponytail",
   hairColor: "#151515",
   outfitName: "무지개 블라우스",
@@ -131,15 +131,36 @@ const DEFAULT_CHARACTER: CharacterConfig = {
   background: "#E9DDFF",
 };
 
-function normalizeHexColor(value: string): string | null {
-  const trimmed = value.trim();
-  if (!HEX_COLOR_PATTERN.test(trimmed)) return null;
-  const normalized = trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
-  return normalized.toUpperCase();
-}
-
 function isSameHexColor(first: string, second: string) {
   return first.toUpperCase() === second.toUpperCase();
+}
+
+function loadSavedCharacter(): CharacterConfig {
+  const savedCharacter = localStorage.getItem(CHARACTER_STORAGE_KEY);
+
+  if (!savedCharacter) {
+    return DEFAULT_CHARACTER;
+  }
+
+  try {
+    const parsed = JSON.parse(savedCharacter) as Partial<CharacterConfig> & {
+      skinTone?: unknown;
+      skinColor?: unknown;
+    };
+    const resolvedSkin = resolveStoredSkinTone(
+      parsed.skinTone,
+      parsed.skinColor,
+    );
+
+    return {
+      ...DEFAULT_CHARACTER,
+      ...parsed,
+      ...resolvedSkin,
+    } as CharacterConfig;
+  } catch {
+    localStorage.removeItem(CHARACTER_STORAGE_KEY);
+    return DEFAULT_CHARACTER;
+  }
 }
 
 export default function AdminCharacterCreatorPage() {
@@ -147,15 +168,15 @@ export default function AdminCharacterCreatorPage() {
   const [searchParams] = useSearchParams();
 
   const [character, setCharacter] =
-    useState<CharacterConfig>(DEFAULT_CHARACTER);
+    useState<CharacterConfig>(() => loadSavedCharacter());
+  const [skinHexInput, setSkinHexInput] = useState(character.skinColor);
+  const [skinHexError, setSkinHexError] = useState("");
   const [backgroundHexInput, setBackgroundHexInput] = useState(
-    DEFAULT_CHARACTER.background,
+    character.background,
   );
   const [backgroundHexError, setBackgroundHexError] = useState("");
 
-  const selectedSkinTone = SKIN_TONES.find(
-    (skinTone) => skinTone.value === character.skinTone,
-  );
+  const isCustomSkinTone = character.skinTone === "custom";
 
   const selectedBackgroundPreset = BACKGROUNDS.find((background) =>
     isSameHexColor(background.color, character.background),
@@ -170,6 +191,73 @@ export default function AdminCharacterCreatorPage() {
       ...prev,
       [key]: value,
     }));
+  }
+
+  function applySkinPreset(
+    skinTone: Exclude<SkinToneSelection, "custom">,
+    skinColor: string,
+  ) {
+    update("skinTone", skinTone);
+    update("skinColor", skinColor);
+    setSkinHexInput(skinColor);
+    setSkinHexError("");
+  }
+
+  function applyCustomSkinColor(value: string) {
+    const normalized = normalizeHexColor(value);
+
+    if (!normalized) {
+      return false;
+    }
+
+    const matchedPreset = findSkinTonePresetByColor(normalized);
+
+    update("skinTone", matchedPreset ?? "custom");
+    update("skinColor", normalized);
+    setSkinHexInput(normalized);
+    setSkinHexError("");
+    return true;
+  }
+
+  function handleSkinHexChange(value: string) {
+    const upperValue = value.toUpperCase();
+    setSkinHexInput(upperValue);
+
+    const normalized = normalizeHexColor(upperValue);
+
+    if (normalized) {
+      applyCustomSkinColor(normalized);
+      return;
+    }
+
+    const hexBody = upperValue.startsWith("#")
+      ? upperValue.slice(1)
+      : upperValue;
+
+    if (!/^[0-9A-F]*$/.test(hexBody)) {
+      setSkinHexError("0-9와 A-F만 입력할 수 있습니다.");
+      return;
+    }
+
+    if (hexBody.length > 6) {
+      setSkinHexError("HEX 색상은 6자리로 입력해주세요.");
+      return;
+    }
+
+    setSkinHexError("");
+  }
+
+  function handleSkinHexBlur() {
+    const normalized = normalizeHexColor(skinHexInput);
+
+    if (normalized) {
+      applyCustomSkinColor(normalized);
+      return;
+    }
+
+    setSkinHexError(
+      "예: #F7C6A8처럼 6자리 HEX 색상 코드를 입력해주세요.",
+    );
   }
 
   function applyBackgroundColor(value: string) {
@@ -225,11 +313,20 @@ export default function AdminCharacterCreatorPage() {
 
   function handleReset() {
     setCharacter(DEFAULT_CHARACTER);
+    setSkinHexInput(DEFAULT_CHARACTER.skinColor);
+    setSkinHexError("");
     setBackgroundHexInput(DEFAULT_CHARACTER.background);
     setBackgroundHexError("");
   }
 
   function handleApply() {
+    if (!normalizeHexColor(skinHexInput)) {
+      setSkinHexError(
+        "피부색을 적용하려면 올바른 6자리 HEX 값을 입력해주세요.",
+      );
+      return;
+    }
+
     if (!normalizeHexColor(backgroundHexInput)) {
       setBackgroundHexError(
         "배경색을 적용하려면 올바른 6자리 HEX 값을 입력해주세요.",
@@ -277,15 +374,18 @@ export default function AdminCharacterCreatorPage() {
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
           <div className="space-y-6">
             <CreatorSection title="피부색 선택">
-              <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-                {SKIN_TONES.map((skinTone) => (
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+                {SKIN_TONE_PRESETS.map((skinTone) => (
                   <OptionCard
                     key={skinTone.value}
                     selected={character.skinTone === skinTone.value}
-                    onClick={() => update("skinTone", skinTone.value)}
+                    onClick={() =>
+                      applySkinPreset(skinTone.value, skinTone.color)
+                    }
+                    ariaLabel={`${skinTone.label} 피부색 선택`}
                   >
                     <div
-                      className="mx-auto h-10 w-32 rounded-full"
+                      className="mx-auto h-10 w-full max-w-32 rounded-full"
                       style={{ backgroundColor: skinTone.color }}
                     />
                     <p className="mt-2 text-xs font-bold text-slate-800">
@@ -293,6 +393,103 @@ export default function AdminCharacterCreatorPage() {
                     </p>
                   </OptionCard>
                 ))}
+              </div>
+
+              <div className="mt-5 rounded-xl border border-slate-200 bg-slate-50 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <h3 className="text-sm font-bold text-slate-800">
+                      사용자 지정 피부색
+                    </h3>
+                    <p className="mt-1 text-xs text-slate-500">
+                      컬러 피커 또는 6자리 HEX 코드로 직접 지정할 수 있습니다.
+                    </p>
+                  </div>
+
+                  {isCustomSkinTone && (
+                    <span className="rounded-full bg-primary px-3 py-1 text-[11px] font-bold text-white">
+                      CUSTOM 선택됨
+                    </span>
+                  )}
+                </div>
+
+                <div className="mt-4 grid gap-3 md:grid-cols-[72px_1fr_150px]">
+                  <div>
+                    <label
+                      htmlFor="custom-skin-color-picker"
+                      className="mb-2 block text-xs font-bold text-slate-700"
+                    >
+                      컬러 피커
+                    </label>
+                    <input
+                      id="custom-skin-color-picker"
+                      type="color"
+                      value={character.skinColor}
+                      onChange={(event) =>
+                        applyCustomSkinColor(event.target.value)
+                      }
+                      className="h-12 w-full cursor-pointer rounded-lg border border-slate-300 bg-white p-1"
+                      aria-label="사용자 지정 피부색 선택"
+                    />
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="custom-skin-hex"
+                      className="mb-2 block text-xs font-bold text-slate-700"
+                    >
+                      HEX 색상 코드
+                    </label>
+                    <input
+                      id="custom-skin-hex"
+                      type="text"
+                      value={skinHexInput}
+                      onChange={(event) =>
+                        handleSkinHexChange(event.target.value)
+                      }
+                      onBlur={handleSkinHexBlur}
+                      placeholder="#F7C6A8"
+                      maxLength={7}
+                      spellCheck={false}
+                      aria-invalid={Boolean(skinHexError)}
+                      aria-describedby="custom-skin-hex-help custom-skin-hex-error"
+                      className={`h-12 w-full rounded-lg border bg-white px-3 font-mono text-sm uppercase outline-none transition ${
+                        skinHexError
+                          ? "border-red-500 focus:border-red-500"
+                          : "border-slate-300 focus:border-primary"
+                      }`}
+                    />
+                    <p
+                      id="custom-skin-hex-help"
+                      className="mt-1 text-[11px] text-slate-500"
+                    >
+                      # 없이 6자리만 입력해도 자동으로 적용됩니다.
+                    </p>
+                    {skinHexError && (
+                      <p
+                        id="custom-skin-hex-error"
+                        className="mt-1 text-xs font-medium text-red-600"
+                      >
+                        {skinHexError}
+                      </p>
+                    )}
+                  </div>
+
+                  <div>
+                    <p className="mb-2 text-xs font-bold text-slate-700">
+                      현재 적용 색상
+                    </p>
+                    <div className="flex h-12 items-center gap-2 rounded-lg border border-slate-300 bg-white px-3">
+                      <span
+                        className="h-7 w-7 shrink-0 rounded border border-slate-200"
+                        style={{ backgroundColor: character.skinColor }}
+                      />
+                      <code className="text-xs font-bold text-slate-700">
+                        {character.skinColor.toUpperCase()}
+                      </code>
+                    </div>
+                  </div>
+                </div>
               </div>
             </CreatorSection>
 
@@ -529,7 +726,7 @@ export default function AdminCharacterCreatorPage() {
             >
               <CharacterModelViewer
                 modelUrl="/models/chibi-base.glb"
-                skinColor={selectedSkinTone?.color ?? "#f7c6a8"}
+                skinColor={character.skinColor}
                 hairColor={character.hairColor}
                 outfitColor={character.outfitColor}
                 hairStyle={character.hairStyle}
@@ -538,6 +735,7 @@ export default function AdminCharacterCreatorPage() {
 
             <div className="mt-4 grid grid-cols-2 gap-2 rounded-lg border border-slate-200 p-4 text-xs text-slate-600">
               <p>피부: {character.skinTone}</p>
+              <p>피부색: {character.skinColor.toUpperCase()}</p>
               <p>헤어: {character.hairStyle}</p>
               <p>의상: {character.outfitName}</p>
               <p>액세서리: {character.accessory}</p>

--- a/src/pages/Admin/AdminConcertFormPage.tsx
+++ b/src/pages/Admin/AdminConcertFormPage.tsx
@@ -19,6 +19,10 @@ import {
 import type { ConcertFormData } from "@/types/domain/admin";
 import type { Genre } from "@/types/domain/concert";
 import CharacterModelViewer from "@/components/admin/character/CharacterModelViewer";
+import {
+  resolveStoredSkinTone,
+  type SkinToneSelection,
+} from "@/components/admin/character/characterSkin";
 
 const GENRES: { value: Genre; label: string }[] = [
   { value: "CONCERT", label: "콘서트" },
@@ -53,7 +57,6 @@ interface Props {
   mode: "create" | "edit";
 }
 
-type CharacterSkinTone = "light" | "medium" | "tan" | "dark";
 type CharacterHairStyle =
   | "short"
   | "long"
@@ -64,7 +67,8 @@ type CharacterHairStyle =
 type CharacterPose = "standing" | "wave" | "heart" | "dance" | "sing";
 
 interface CharacterDraft {
-  skinTone: CharacterSkinTone;
+  skinTone: SkinToneSelection;
+  skinColor: string;
   hairStyle: CharacterHairStyle;
   hairColor: string;
   outfitName: string;
@@ -74,13 +78,6 @@ interface CharacterDraft {
   background: string;
 }
 
-const CHARACTER_SKIN_COLORS: Record<CharacterSkinTone, string> = {
-  light: "#f7c6a8",
-  medium: "#d9a78c",
-  tan: "#bf7f54",
-  dark: "#8b5a2b",
-};
-
 function loadSavedCharacter(): CharacterDraft | null {
   const savedCharacter = localStorage.getItem(CHARACTER_STORAGE_KEY);
 
@@ -89,7 +86,22 @@ function loadSavedCharacter(): CharacterDraft | null {
   }
 
   try {
-    return JSON.parse(savedCharacter) as CharacterDraft;
+    const parsed = JSON.parse(savedCharacter) as Omit<
+      CharacterDraft,
+      "skinTone" | "skinColor"
+    > & {
+      skinTone?: unknown;
+      skinColor?: unknown;
+    };
+    const resolvedSkin = resolveStoredSkinTone(
+      parsed.skinTone,
+      parsed.skinColor,
+    );
+
+    return {
+      ...parsed,
+      ...resolvedSkin,
+    } as CharacterDraft;
   } catch {
     localStorage.removeItem(CHARACTER_STORAGE_KEY);
     return null;
@@ -824,7 +836,7 @@ function CharacterCreatorLinkBox({
       >
         <CharacterModelViewer
           modelUrl="/models/chibi-base.glb"
-          skinColor={CHARACTER_SKIN_COLORS[character.skinTone]}
+          skinColor={character.skinColor}
           hairColor={character.hairColor}
           outfitColor={character.outfitColor}
           hairStyle={character.hairStyle}
@@ -837,7 +849,7 @@ function CharacterCreatorLinkBox({
         </p>
 
         <p className="mt-1 text-xs text-admin-text-secondary">
-          피부: {character.skinTone} / 헤어: {character.hairStyle} / 포즈:{" "}
+          피부: {character.skinTone} ({character.skinColor.toUpperCase()}) / 헤어: {character.hairStyle} / 포즈:{" "}
           {character.pose}
         </p>
 


### PR DESCRIPTION
## 🔗 관련 이슈

- Related to #78

---

## 📌 주요 변경 사항

- 기본 피부색 프리셋을 4종에서 5종으로 확장
- 사용자 지정 피부색 컬러 피커 추가
- 6자리 HEX 색상 코드 직접 입력 및 유효성 검사 추가
- 프리셋 ID와 실제 피부색 HEX 값을 분리하여 저장
- 캐릭터 제작 화면과 공연 등록 화면 간 피부색 유지
- 기존 피부색 저장 데이터 호환 처리

---

## 🛠 상세 구현 내용

- `characterSkin.ts` 공용 파일 추가
  - 피부색 프리셋 타입 및 상수
  - 기본 피부색과 기본 HEX 값
  - HEX 유효성 검사 및 정규화
  - 기존 저장값 변환 로직

- 기본 피부색 프리셋 5종 제공
  - Light
  - Light Medium
  - Medium
  - Tan
  - Dark

- 사용자 지정 피부색 기능 추가
  - 브라우저 컬러 피커
  - `#RRGGBB` 형식 HEX 입력
  - `#` 없이 입력한 6자리 값 자동 정규화
  - 잘못된 입력값 오류 표시
  - 마지막 정상 피부색 유지
  - Custom 선택 상태 표시

- 캐릭터 설정에 실제 `skinColor` HEX 값 저장
- 캐릭터 제작 페이지에서 피부색 실시간 반영
- 공연 등록 화면의 3D 미리보기에 동일한 피부색 적용
- 기존 `light`, `medium`, `tan`, `dark` 데이터 호환 처리
- 잘못된 저장값은 기본 피부색으로 fallback

---

## ✅ 테스트

- [x] 기본 피부색 프리셋 5종 선택 확인
- [x] 컬러 피커 피부색 변경 확인
- [x] HEX 색상 코드 직접 입력 확인
- [x] `#` 없는 HEX 입력 정규화 확인
- [x] 잘못된 HEX 입력 오류 표시 확인
- [x] 초기화 시 기본 피부색 복원 확인
- [x] 공연 등록 화면 복귀 후 피부색 유지 확인
- [x] 기존 피부색 저장 데이터 호환 확인
- [x] `npm run build` 통과
- [x] `npm run lint` 통과

---

## 📷 스크린샷
<img width="452" height="197" alt="{307061DD-6489-46AE-86F8-616974D7E7E1}" src="https://github.com/user-attachments/assets/e3bb7e0e-a163-46f7-af35-0009300822ad" />
