### PR TITLE
[Feat] #122 좌석 배치/상태/카운트 실 API 연동

### DIFF
--- a/src/api/seats.ts
+++ b/src/api/seats.ts
@@ -1,9 +1,10 @@
 // 좌석 API — 백엔드 seat-service swagger (2026-07-07) 스펙 반영
 //
 // 백엔드 endpoint 매핑:
-//   fetchSeatCounts       → GET /api/v1/seat/{performanceId}/seat-counts  (이슈 #121)
-//   fetchSeats            → GET /api/v1/seat/{performanceId}/seat-layouts (이슈 #122)
-//   fetchSeatNumbers      → GET /api/v1/seat/numbers                      (이슈 #122)
+//   fetchSeatCounts / fetchSeatLayouts → 이슈 #122 실 API
+//   fetchSeatCounts       → GET /api/v1/seat/{performanceId}/seat-counts  (이슈 #121/#122)
+//   fetchSeats / fetchSeatLayouts → GET /api/v1/seat/{performanceId}/seat-layouts (이슈 #122)
+//   fetchSeatNumbers      → GET /api/v1/seat/numbers?seatIds=1&seatIds=2   (이슈 #122)
 //   subscribeSeatStream   → GET /api/v1/seat/{performanceId}/seat-status/stream (이슈 #123 SSE)
 //
 // ⚠️ 백엔드 응답이 snake_case (total_count 등) 이지만
@@ -101,7 +102,7 @@ export async function fetchSeatCounts(
 // -------------------------------------------------------
 
 /**
- * 공연 좌석 배치 + 상태 조회.
+ * 공연 좌석 배치 + 상태 조회 (이슈 #122).
  * 백엔드: GET /api/v1/seat/{performanceId}/seat-layouts
  *
  * 응답: SeatLayoutResponse[]
@@ -123,9 +124,15 @@ export async function fetchSeats(
   return (res.data ?? []).map(mapSeatLayout);
 }
 
+/** 이슈 #122 네이밍 별칭 — fetchSeats와 동일 (좌석 배치 실 API) */
+export const fetchSeatLayouts = fetchSeats;
+
 /**
- * 좌석 ID 배열로 좌석 번호 조회.
+ * 좌석 ID 배열로 좌석 번호 조회 (이슈 #122).
  * 백엔드: GET /api/v1/seat/numbers?seatIds=1&seatIds=2
+ *
+ * Spring 반복 파라미터 형식 유지: seatIds=1&seatIds=2
+ * (axios 기본 직렬화의 seatIds[]= 형태 방지)
  *
  * 사용처: 예매 목록 페이지에서 seatId만 있는 예매 항목의 좌석 번호 조회 등.
  */
@@ -145,7 +152,11 @@ export async function fetchSeatNumbers(
 
   const res = await apiClient.get<BackendSeatNumberResponse[]>(
     "/api/v1/seat/numbers",
-    { params: { seatIds } },
+    {
+      params: { seatIds },
+      // indexes: null → seatIds=1&seatIds=2 (repeat)
+      paramsSerializer: { indexes: null },
+    },
   );
   return res.data ?? [];
 }

--- a/src/hooks/queries/useSeats.ts
+++ b/src/hooks/queries/useSeats.ts
@@ -1,5 +1,7 @@
-// 좌석 + 잔여수 조회
-// staleTime: 0 — 실시간 데이터 (메모리 리마인더 Sprint 5)
+// 좌석 배치 + 잔여수 조회 (이슈 #122)
+// - useSeats / useSeatLayouts: seat-layouts (좌석맵)
+// - useSeatCounts: seat-counts (상태별 수)
+// staleTime: 0 — 좌석맵은 실시간 (SSE #123과 병행)
 import { useQuery } from "@tanstack/react-query";
 import { fetchSeats, fetchSeatCounts } from "@/api/seats";
 import { queryKeys } from "@/constants/queryKeys";
@@ -14,6 +16,9 @@ export function useSeats(performanceId: number | undefined) {
     staleTime: 0, // 실시간
   });
 }
+
+/** 이슈 #122 네이밍 별칭 — useSeats와 동일 */
+export const useSeatLayouts = useSeats;
 
 export function useSeatCounts(performanceId: number | undefined) {
   return useQuery({

--- a/src/pages/Booking/SeatSelectionPage.tsx
+++ b/src/pages/Booking/SeatSelectionPage.tsx
@@ -5,6 +5,10 @@
 //   - seat 삭제 (백엔드 스펙엔 좌석 단위 가격 없음)
 //   - totalAmount 계산: selectedSeat 제거, currentConcert만 사용
 //
+// 이슈 #122:
+//   - 좌석맵: useSeats (seat-layouts)
+//   - 잔여/상태별 통계: useSeatCounts (seat-counts) — layouts 배열을 직접 집계하지 않음
+//
 // ⚠️ 아키텍처 변경 (이슈 #124):
 //   백엔드에 별도 좌석 HOLD API 없음. 예매 생성(POST /booking, PENDING 상태)이
 //   좌석 HOLD를 겸함. useHoldSeat(seatId만 전달) → useCreateBooking(performanceId+seatId)로 교체.
@@ -12,10 +16,9 @@
 //   결제 페이지/예매 확인 페이지에서 결제·취소 시 사용 가능.
 import { useNavigate, useParams } from "react-router-dom";
 import { X, Clock, CheckCircle2, AlertCircle } from "lucide-react";
-import { useMemo } from "react";
 import SeatMap from "@/components/seat/SeatMap";
 import SeatLegend from "@/components/seat/SeatLegend";
-import { useSeats } from "@/hooks/queries/useSeats";
+import { useSeats, useSeatCounts } from "@/hooks/queries/useSeats";
 import { useSeatEventStream } from "@/hooks/seat/useSeatEventStream";
 import { useCreateBooking } from "@/hooks/mutations/useCreateBooking";
 import useSeatStore from "@/stores/reservation/seatStore";
@@ -35,21 +38,20 @@ export default function SeatSelectionPage() {
   const startTimer = useTimerStore((s) => s.startTimer);
   const currentConcert = useConcertStore((s) => s.currentConcert);
 
+  // #122: layouts → 좌석맵, counts → 하단 잔여/상태 통계
   const { data: seats, isLoading, isError } = useSeats(performanceId);
+  const { data: seatCounts } = useSeatCounts(performanceId);
   const createBookingMutation = useCreateBooking();
 
-  // SSE 구독
+  // SSE 구독 (#123에서 polling fallback 보강)
   useSeatEventStream(performanceId);
 
-  const stats = useMemo(() => {
-    if (!seats) return { total: 0, available: 0, holding: 0, sold: 0 };
-    return {
-      total: seats.length,
-      available: seats.filter((s) => s.status === "AVAILABLE").length,
-      holding: seats.filter((s) => s.status === "HOLD").length,
-      sold: seats.filter((s) => s.status === "SOLD").length,
-    };
-  }, [seats]);
+  const stats = {
+    total: seatCounts?.totalCount ?? 0,
+    available: seatCounts?.availableCount ?? 0,
+    holding: seatCounts?.holdCount ?? 0,
+    sold: seatCounts?.soldCount ?? 0,
+  };
 
   // 좌석 단위 가격 없음 → 공연 단가 사용 (백엔드 스펙)
   const totalAmount = currentConcert?.price ?? 0;


### PR DESCRIPTION
## 🔗 관련 이슈
- close #122
---
## 📌 주요 변경 사항
- `fetchSeatLayouts` 별칭 추가 (`fetchSeats`와 동일 — seat-layouts)
- `SeatSelectionPage` 잔여/상태 통계를 `useSeatCounts`(seat-counts)로 표시
- `fetchSeatNumbers`의 `seatIds`를 Spring 반복 형식(`seatIds=1&seatIds=2`)으로 직렬화
- `useSeatLayouts` 별칭 추가 (`useSeats`와 동일)
***
## 🛠 상세 구현 내용
- `src/api/seats.ts`: `export const fetchSeatLayouts = fetchSeats`, `paramsSerializer: { indexes: null }`
- `src/hooks/queries/useSeats.ts`: `useSeatLayouts` alias + #122 주석
- `src/pages/Booking/SeatSelectionPage.tsx`: 좌석맵은 `useSeats`, 하단 통계는 `useSeatCounts` (createBooking/#124 플로우 유지)
- 필드명 `seatNumber` / `AVAILABLE|HOLD|SOLD` 기존 매핑 유지 (row/col은 seatNumber에서 파생)
- 좌석 번호 API는 이슈 초안의 `/{id}/seat-numbers`가 아니라 BE 실경로 `/api/v1/seat/numbers` 사용
***
## ✅ 테스트
### 테스트 방법
- 좌석 선택 페이지 진입 → 좌석맵 렌더 + 하단 전체/예매가능/진행중/판매완료가 counts API와 일치하는지 확인
- 예매 목록 등 `fetchSeatNumbers` 호출 시 Network 탭에서 `seatIds=1&seatIds=2` 형식 확인
- 좌석 확인 → createBooking(#124) 플로우 회귀
### 테스트 결과
- `tsc --noEmit` 통과 (로컬)
### 📸 스크린샷
---
## 👀 리뷰 요청 사항
- counts와 layouts 정합성(카운트 API vs 맵 집계) 접근이 맞는지
- PR base를 `feature/124-125`로 둔 스택 전략이 맞는지
***
## ⚠️ 배포 시 주의사항
- seat-service의 `/seat-layouts`, `/seat-counts`, `/seat/numbers` 실 API·CORS 확인
- #123(SSE)과 함께 배포하는 것을 권장 (실시간 갱신은 별도 PR)