### PR TITLE
[Feat] #123 SSE로 좌석 상태 실시간 동기화

### DIFF
--- a/src/api/seats.ts
+++ b/src/api/seats.ts
@@ -1,4 +1,4 @@
-// 좌석 API — 백엔드 seat-service swagger (2026-07-07) 스펙 반영
+// 좌석 API — 백엔드 seat-service (develop, 2026-07-25 소스 확인) 스펙 반영
 //
 // 백엔드 endpoint 매핑:
 //   fetchSeatCounts / fetchSeatLayouts → 이슈 #122 실 API
@@ -9,10 +9,10 @@
 //
 // ⚠️ 백엔드 응답이 snake_case (total_count 등) 이지만
 // instance.ts의 axios-case-converter가 camelCase로 자동 변환.
+// 단, EventSource(SSE)는 axios를 거치지 않으므로 이 변환이 적용되지 않는다 (아래 subscribeSeatStream 참고).
 //
-// ⚠️ SSE 이벤트 payload 스펙 미확정 (백엔드 swagger에 SseEmitter만 있음).
-// 현재 프론트는 { seatId, status, timestamp } 가정 스펙 사용.
-// 실제 스펙 확정 시 매핑 로직 조정 필요.
+// ⚠️ seat-service SecurityConfig 확인 결과 전체 anyRequest().permitAll()
+// (내부 전용 /api/v1/internal/seat/**만 인증 필요) → 조회/SSE 엔드포인트는 인증 헤더 불필요.
 import type {
   SeatCounts,
   SeatStatus,
@@ -165,57 +165,99 @@ export async function fetchSeatNumbers(
 // Public API — SSE 좌석 상태 스트림 (이슈 #123)
 // -------------------------------------------------------
 
+/** 백엔드 SeatStatusChangedResponse의 실제 SSE 원본 payload (snake_case, Jackson NON_NULL) */
+interface BackendSeatStatusChangedEventRaw {
+  performance_id: number;
+  seat_id: number;
+  seat_layout_id: number;
+  seat_number: string;
+  seat_status: SeatStatus;
+  /** HOLD가 아니면 필드 자체가 없을 수 있음 (NON_NULL) */
+  hold_expired_at?: string;
+}
+
+function parseSeatUpdateEvent(raw: string): SeatUpdateEvent | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<BackendSeatStatusChangedEventRaw>;
+    if (typeof parsed.seat_id !== "number" || !parsed.seat_status) {
+      return null;
+    }
+    return {
+      seatId: parsed.seat_id,
+      status: parsed.seat_status,
+      performanceId: parsed.performance_id,
+      seatLayoutId: parsed.seat_layout_id,
+      seatNumber: parsed.seat_number,
+      holdExpiredAt: parsed.hold_expired_at,
+    };
+  } catch (error) {
+    console.error("[SSE] 이벤트 파싱 실패:", error, raw);
+    return null;
+  }
+}
+
+export interface SubscribeSeatStreamCallbacks {
+  /** SSE 연결 오류/단절 시 (polling fallback 트리거용) */
+  onError?: (error: Event) => void;
+  /** SSE 연결(최초 연결 or 재연결) 성공 시 (polling 중지용) */
+  onOpen?: () => void;
+}
+
 /**
- * 좌석 상태 SSE 구독.
+ * 좌석 상태 SSE 구독 (이슈 #123).
  * 백엔드: GET /api/v1/seat/{performanceId}/seat-status/stream
  *
- * ⚠️ SSE 이벤트 payload 스펙 백엔드 확정 대기 (현재 가정 스펙):
- *   {
- *     "seatId": 1,
- *     "status": "AVAILABLE" | "HOLD" | "SOLD",
- *     "timestamp": "2026-07-15T10:00:00Z"
- *   }
+ * 이벤트:
+ *   - named `seat-status-changed` (주 경로, 백엔드 SeatStatusSseEventSender 확인)
+ *   - named `connected` (연결 시 1회, plain string "connected" — JSON 아님, 무시)
+ *   - unnamed onmessage (백엔드가 event 없이 보낼 가능성 대비 fallback)
  *
- * 실 API 시 EventSource 사용. 인증 헤더 필요할 경우 EventSourcePolyfill 등 검토.
+ * ⚠️ payload는 백엔드 전역 Jackson SNAKE_CASE 설정 그대로 온다
+ * (EventSource는 axios-case-converter를 거치지 않음). parseSeatUpdateEvent에서 변환.
  *
- * @returns 구독 해제 함수 (unsubscribe)
+ * ⚠️ seat-service는 anyRequest().permitAll() → 인증 헤더 불필요.
+ * withCredentials는 실질적 효과 없지만 향후 쿠키 인증 도입 대비 유지.
+ *
+ * @returns 구독 해제 함수 (unsubscribe) — unmount 시 EventSource.close()
  */
 export function subscribeSeatStream(
   performanceId: number,
   onEvent: (event: SeatUpdateEvent) => void,
+  callbacks?: SubscribeSeatStreamCallbacks,
 ): () => void {
   if (USE_MOCK) {
+    // Mock은 연결이 항상 성공한 것으로 취급 (polling fallback 트리거 없음)
+    callbacks?.onOpen?.();
     return mockSubscribeSeats(performanceId, onEvent);
   }
 
-  // ⚠️ EventSource는 브라우저 표준 API. 인증 헤더 미지원 (쿠키만 자동 포함).
-  // 백엔드가 JWT 헤더 인증을 요구한다면 EventSourcePolyfill 등 라이브러리 필요.
-  // 이 부분은 백엔드 인증 방식 확정 후 조정.
   const baseUrl = import.meta.env.VITE_API_BASE_URL || "";
   const url = `${baseUrl}/api/v1/seat/${performanceId}/seat-status/stream`;
 
   const eventSource = new EventSource(url, { withCredentials: true });
 
-  eventSource.onmessage = (message) => {
-    try {
-      const parsed = JSON.parse(message.data);
-      // ⚠️ 백엔드 payload 스펙 확정 후 필드 매핑 조정
-      onEvent({
-        seatId: parsed.seatId,
-        status: parsed.status ?? parsed.seatStatus,
-        timestamp: parsed.timestamp ?? new Date().toISOString(),
-      });
-    } catch (error) {
-      console.error("[SSE] 이벤트 파싱 실패:", error, message.data);
-    }
+  const handleMessage = (message: MessageEvent<string>) => {
+    const event = parseSeatUpdateEvent(message.data);
+    if (event) onEvent(event);
   };
+
+  // 주 경로: named SSE event (백엔드 EVENT_NAME = "seat-status-changed")
+  eventSource.addEventListener("seat-status-changed", handleMessage);
+  // fallback: event 이름 없는 기본 message
+  eventSource.onmessage = handleMessage;
+
+  eventSource.addEventListener("open", () => {
+    callbacks?.onOpen?.();
+  });
 
   eventSource.onerror = (error) => {
     console.error("[SSE] 연결 오류:", error);
-    // EventSource는 자동 재연결 시도. 로깅만 남기고 그대로 유지.
+    callbacks?.onError?.(error);
+    // EventSource는 자동 재연결 시도. 재연결 성공 시 open 이벤트 → onOpen에서 polling 중지.
   };
 
   return () => {
+    eventSource.removeEventListener("seat-status-changed", handleMessage);
     eventSource.close();
   };
 }

--- a/src/hooks/seat/useSeatEventStream.ts
+++ b/src/hooks/seat/useSeatEventStream.ts
@@ -1,10 +1,15 @@
-// 좌석 상태 SSE 구독 hook
-// SSE 이벤트 수신 시 React Query 캐시를 직접 patch
+// 좌석 상태 SSE 구독 hook (이슈 #123)
+// - SSE(named event: seat-status-changed)가 주 경로
+// - 연결 실패/단절 시 5초 polling fallback (좌석맵 + 카운트 재조회)
+// - SSE 재연결(open) 시 polling 중지
+// - unmount 시 EventSource.close + clearInterval
 import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { subscribeSeatStream } from "@/api/seats";
 import { queryKeys } from "@/constants/queryKeys";
 import type { SeatWithStatus, SeatUpdateEvent } from "@/types/domain/seat";
+
+const POLL_INTERVAL_MS = 5_000;
 
 export function useSeatEventStream(performanceId: number | undefined) {
   const queryClient = useQueryClient();
@@ -12,29 +17,62 @@ export function useSeatEventStream(performanceId: number | undefined) {
   useEffect(() => {
     if (!performanceId) return;
 
-    const unsubscribe = subscribeSeatStream(
-      performanceId,
-      (event: SeatUpdateEvent) => {
-        // 캐시의 좌석 한 개만 patch (전체 다시 가져오지 않음)
-        queryClient.setQueryData<SeatWithStatus[]>(
-          queryKeys.seats.byPerformance(performanceId),
-          (old) => {
-            if (!old) return old;
-            return old.map((seat) =>
-              seat.id === event.seatId
-                ? { ...seat, status: event.status }
-                : seat,
-            );
-          },
-        );
+    let disposed = false;
+    let pollingId: ReturnType<typeof setInterval> | null = null;
 
-        // 좌석 잔여 수도 같이 무효화 (간단히 다시 fetch)
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.seats.counts(performanceId),
-        });
+    const applySeatUpdate = (event: SeatUpdateEvent) => {
+      queryClient.setQueryData<SeatWithStatus[]>(
+        queryKeys.seats.byPerformance(performanceId),
+        (old) => {
+          if (!old) return old;
+          return old.map((seat) =>
+            seat.id === event.seatId
+              ? { ...seat, status: event.status }
+              : seat,
+          );
+        },
+      );
+
+      // 좌석 잔여 수도 같이 무효화 (간단히 다시 fetch)
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.seats.counts(performanceId),
+      });
+    };
+
+    const stopPolling = () => {
+      if (pollingId == null) return;
+      clearInterval(pollingId);
+      pollingId = null;
+    };
+
+    const pollOnce = () => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.seats.byPerformance(performanceId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.seats.counts(performanceId),
+      });
+    };
+
+    const startPolling = () => {
+      if (disposed || pollingId != null) return;
+      pollOnce();
+      pollingId = setInterval(pollOnce, POLL_INTERVAL_MS);
+    };
+
+    const unsubscribe = subscribeSeatStream(performanceId, applySeatUpdate, {
+      onError: () => {
+        startPolling();
       },
-    );
+      onOpen: () => {
+        stopPolling();
+      },
+    });
 
-    return unsubscribe;
+    return () => {
+      disposed = true;
+      stopPolling();
+      unsubscribe();
+    };
   }, [performanceId, queryClient]);
 }

--- a/src/types/domain/seat.ts
+++ b/src/types/domain/seat.ts
@@ -50,12 +50,27 @@ export interface SeatCounts {
   soldCount: number;
 }
 
-/** SSE 이벤트 페이로드 — 백엔드 확정 대기 (가상 스펙) */
+/**
+ * SSE 이벤트 페이로드 — 백엔드 SeatStatusChangedResponse 대응 (이슈 #123, BE 소스 확인 완료)
+ *
+ * 백엔드 원본 필드(snake_case): performance_id, seat_id, seat_layout_id,
+ * seat_number, seat_status, hold_expired_at.
+ * EventSource는 axios를 거치지 않아 axios-case-converter가 적용되지 않으므로,
+ * subscribeSeatStream 내부에서 snake_case → camelCase로 직접 변환해 이 타입으로 전달한다.
+ *
+ * hold_expired_at은 백엔드 Jackson NON_NULL 설정으로 null일 때 필드 자체가 생략됨
+ * (HOLD가 아닌 상태에서는 대부분 없음).
+ */
 export interface SeatUpdateEvent {
   seatId: number;
   status: SeatStatus;
-  /** ISO datetime */
-  timestamp: string;
+  performanceId?: number;
+  seatLayoutId?: number;
+  seatNumber?: string;
+  /** HOLD 만료 예정 시각 — 백엔드 포맷 "yyyy-MM-dd HH:mm:ss" (ISO 아님) */
+  holdExpiredAt?: string;
+  /** @deprecated 백엔드 페이로드에 없음. Mock 시뮬레이터 호환용으로만 유지. */
+  timestamp?: string;
 }
 
 /**


### PR DESCRIPTION
## 🔗 관련 이슈
- close #123
---
## 📌 주요 변경 사항
- SSE named 이벤트 `seat-status-changed` 구독 + unnamed `onmessage` fallback
- SSE payload가 axios를 거치지 않아 snake_case로 오는 것을 확인하고 정확히 파싱 (`seat_id`, `seat_status` 등)
- SSE 오류/단절 시 5초 polling (`layouts` + `counts` invalidate)
- SSE `open`(재연결) 시 polling 중지
- unmount 시 `EventSource.close()` + `clearInterval`
***
## 🛠 상세 구현 내용
- 백엔드 `SeatStatusChangedResponse`, `SeatStatusSseEventSender` 소스 직접 확인 후 구현
- `subscribeSeatStream`: `addEventListener('seat-status-changed')`, `onmessage` fallback, snake_case → camelCase 매핑, `onError`/`onOpen` 콜백
- `useSeatEventStream`: SSE 주 경로 + 5s polling fallback + cleanup
- `SeatUpdateEvent` 타입을 백엔드 확정 스펙 기준으로 갱신
***
## ✅ 테스트
### 테스트 방법
- 좌석 선택 페이지 진입 → SSE(또는 mock)로 SeatItem 상태 갱신 확인
- SSE 차단/실패 유도 → 약 5초마다 layouts/counts 재조회 확인
- SSE 복구 시 polling 중지 확인
- 페이지 이탈 시 EventSource 종료·interval 정리 확인
### 테스트 결과
- `tsc --noEmit` 통과 (로컬)
### 📸 스크린샷
---
## 👀 리뷰 요청 사항
- 백엔드 SSE payload snake_case 확인 내용이 실제 배포 환경에서도 동일한지 (Jackson 전역 설정 기준 추정)
- EventSource 자동 재연결 + polling 동시 동작 시 중복 fetch 허용 여부
***
## ⚠️ 배포 시 주의사항
- seat-service는 `anyRequest().permitAll()` 확인됨 — 인증 헤더 불필요
- gateway `seat-sse-service` 라우트가 `response-timeout: -1`로 이미 스트리밍 대응됨 (추가 설정 불필요)
- #122 이후 스택 머지 권장