### PR TITLE
[Feat] #135 관리자 환불 모니터링 실 API 연동

### DIFF
--- a/src/api/bookings.ts
+++ b/src/api/bookings.ts
@@ -323,10 +323,15 @@ async function toAdminRefundListResponse(
   );
 
   const seatIds = Array.from(new Set(items.map((i) => i.seatId)));
-  const seatNumbersArr = await fetchSeatNumbers(seatIds);
-  const seatNumberMap = new Map(
-    seatNumbersArr.map((s) => [s.seatId, s.seatNumber]),
-  );
+  let seatNumberMap = new Map<number, string>();
+  try {
+    const seatNumbersArr = await fetchSeatNumbers(seatIds);
+    seatNumberMap = new Map(
+      seatNumbersArr.map((s) => [s.seatId, s.seatNumber]),
+    );
+  } catch (error) {
+    console.warn("Failed to fetch seat numbers for refund list:", error);
+  }
 
   const richItems = items.map((i) => ({
     ...i,

--- a/src/api/bookings.ts
+++ b/src/api/bookings.ts
@@ -23,6 +23,9 @@ import type {
   MyBookingsParams,
   MyBookingsResponse,
   MyBookingCountResponse,
+  AdminRefundBookingItem,
+  AdminRefundBookingListParams,
+  AdminRefundBookingListResponse,
 } from "@/types/domain/booking";
 import {
   mockCreateBooking,
@@ -30,6 +33,9 @@ import {
   mockGetMyBookings,
   mockGetMyBookingCount,
   mockCancelBooking,
+  mockGetRefundFailedBookings,
+  mockGetRefundingStuckBookings,
+  mockRetryRefund,
 } from "./mocks/bookings";
 import { fetchConcertDetail } from "./concerts";
 import { fetchSeatNumbers } from "./seats";
@@ -253,4 +259,117 @@ export async function cancelBookingApi(bookingNumber: string): Promise<void> {
   if (USE_MOCK) return mockCancelBooking(bookingNumber);
 
   await apiClient.delete(`/api/v1/booking/${bookingNumber}`);
+}
+
+// -------------------------------------------------------
+// 관리자: 환불 모니터링 (booking-service admin, 2026-07-18 실측으로 확인된 실 API)
+// -------------------------------------------------------
+
+/** 백엔드 BookingSummaryResponse (관리자 환불 조회용, userId/refundFailedAt/updatedAt 포함) */
+interface BackendAdminRefundBooking {
+  bookingId: number;
+  bookingNumber: string;
+  userId: number;
+  performanceId: number;
+  seatId: number;
+  bookingStatus: BookingStatus;
+  confirmedAt: string | null;
+  refundFailedAt: string | null;
+  updatedAt: string;
+}
+
+//
+// 관리자 환불 목록 응답 조회 후 공연명/좌석번호 aggregation.
+
+// ⚠️ 백엔드 응답에 사용자 이름/이메일이 없음 (userId만 존재).
+// 프론트에서 호출 가능한 "userId → 사용자 정보" 조회 API가 없어
+// (auth-info는 internal 전용) 사용자 식별 정보는 표시 불가.
+
+async function toAdminRefundListResponse(
+  raw: BackendAdminRefundBooking[],
+  requestedSize: number,
+): Promise<AdminRefundBookingListResponse> {
+  const items: AdminRefundBookingItem[] = raw.map((b) => ({
+    bookingId: b.bookingId,
+    bookingNumber: b.bookingNumber,
+    userId: b.userId,
+    performanceId: b.performanceId,
+    seatId: b.seatId,
+    status: b.bookingStatus,
+    confirmedAt: b.confirmedAt,
+    refundFailedAt: b.refundFailedAt,
+    updatedAt: b.updatedAt,
+  }));
+
+  if (items.length === 0) {
+    return { items: [], hasNext: false };
+  }
+
+  const uniquePerformanceIds = Array.from(
+    new Set(items.map((i) => i.performanceId)),
+  );
+  const concertsMap = new Map<
+    number,
+    Awaited<ReturnType<typeof fetchConcertDetail>>
+  >();
+  await Promise.all(
+    uniquePerformanceIds.map(async (id) => {
+      try {
+        concertsMap.set(id, await fetchConcertDetail(id));
+      } catch (error) {
+        console.warn(`Failed to fetch concert ${id}:`, error);
+      }
+    }),
+  );
+
+  const seatIds = Array.from(new Set(items.map((i) => i.seatId)));
+  const seatNumbersArr = await fetchSeatNumbers(seatIds);
+  const seatNumberMap = new Map(
+    seatNumbersArr.map((s) => [s.seatId, s.seatNumber]),
+  );
+
+  const richItems = items.map((i) => ({
+    ...i,
+    performanceTitle: concertsMap.get(i.performanceId)?.title ?? "삭제된 공연",
+    seatNumber: seatNumberMap.get(i.seatId) ?? "?",
+  }));
+
+  return { items: richItems, hasNext: items.length === requestedSize };
+}
+
+/** 백엔드: GET /api/v1/booking/admin/bookings/refund-failed (환불 처리 자체가 실패한 건) */
+export async function getRefundFailedBookingsApi(
+  params: AdminRefundBookingListParams = {},
+): Promise<AdminRefundBookingListResponse> {
+  if (USE_MOCK) return mockGetRefundFailedBookings(params);
+
+  const page = params.page ?? 0;
+  const size = params.size ?? 20;
+  const res = await apiClient.get<BackendAdminRefundBooking[]>(
+    "/api/v1/booking/admin/bookings/refund-failed",
+    { params: { page, size } },
+  );
+  return toAdminRefundListResponse(res.data ?? [], size);
+}
+
+/** 백엔드: GET /api/v1/booking/admin/bookings/refunding-stuck (REFUNDING 상태로 멈춰있는 건) */
+export async function getRefundingStuckBookingsApi(
+  params: AdminRefundBookingListParams = {},
+): Promise<AdminRefundBookingListResponse> {
+  if (USE_MOCK) return mockGetRefundingStuckBookings(params);
+
+  const page = params.page ?? 0;
+  const size = params.size ?? 20;
+  const res = await apiClient.get<BackendAdminRefundBooking[]>(
+    "/api/v1/booking/admin/bookings/refunding-stuck",
+    { params: { page, size } },
+  );
+  return toAdminRefundListResponse(res.data ?? [], size);
+}
+
+/** 백엔드: POST /api/v1/booking/admin/{bookingNumber}/refund-retry */
+export async function retryRefundApi(bookingNumber: string): Promise<void> {
+  if (USE_MOCK) return mockRetryRefund(bookingNumber);
+
+  await apiClient.post(`/api/v1/booking/admin/${bookingNumber}/refund-retry`);
 }

--- a/src/api/mocks/bookings.ts
+++ b/src/api/mocks/bookings.ts
@@ -18,6 +18,9 @@ import type {
   MyBookingsParams,
   MyBookingsResponse,
   BookingStatus,
+  AdminRefundBookingItem,
+  AdminRefundBookingListParams,
+  AdminRefundBookingListResponse,
 } from "@/types/domain/booking";
 import { MOCK_CONCERTS } from "./concerts";
 
@@ -234,4 +237,93 @@ export function _findMockBookingBySeat(
       b.seatId === seatId &&
       (b.status === "PENDING" || b.status === "CONFIRMED"),
   );
+}
+
+// ── 관리자: 환불 모니터링 (mock) ────────────────────────
+// 백엔드 GET /booking/admin/bookings/refund-failed, refunding-stuck 흉내.
+// 실제 유저 booking 데이터와 별개인 고정 mock 세트 — 데모/개발용.
+const MOCK_REFUND_FAILED: AdminRefundBookingItem[] = [
+  {
+    bookingId: 901,
+    bookingNumber: "R9F01-ZK3Q8",
+    userId: 12,
+    performanceId: 1,
+    seatId: 15,
+    status: "CANCELED",
+    confirmedAt: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+    refundFailedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    updatedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    bookingId: 902,
+    bookingNumber: "R9F02-LM8T4",
+    userId: 27,
+    performanceId: 4,
+    seatId: 61,
+    status: "CANCELED",
+    confirmedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+    refundFailedAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+    updatedAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+  },
+];
+
+const MOCK_REFUNDING_STUCK: AdminRefundBookingItem[] = [
+  {
+    bookingId: 910,
+    bookingNumber: "R9S01-PX2N7",
+    userId: 8,
+    performanceId: 3,
+    seatId: 90,
+    status: "REFUNDING",
+    confirmedAt: new Date(Date.now() - 9 * 24 * 60 * 60 * 1000).toISOString(),
+    refundFailedAt: null,
+    updatedAt: new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(),
+  },
+];
+
+async function toAdminRefundListResponse(
+  items: AdminRefundBookingItem[],
+  params: AdminRefundBookingListParams,
+): Promise<AdminRefundBookingListResponse> {
+  const size = params.size ?? 20;
+  const page = params.page ?? 0;
+  const paged = items.slice(page * size, page * size + size);
+
+  const richItems = paged.map((b) => {
+    const concert = MOCK_CONCERTS.find((c) => c.id === b.performanceId);
+    return {
+      ...b,
+      performanceTitle: concert?.title ?? "알 수 없는 공연",
+      seatNumber: `mock-seat-${b.seatId}`,
+    };
+  });
+
+  return { items: richItems, hasNext: page * size + size < items.length };
+}
+
+export async function mockGetRefundFailedBookings(
+  params: AdminRefundBookingListParams,
+): Promise<AdminRefundBookingListResponse> {
+  await mockDelay(400);
+  return toAdminRefundListResponse(MOCK_REFUND_FAILED, params);
+}
+
+export async function mockGetRefundingStuckBookings(
+  params: AdminRefundBookingListParams,
+): Promise<AdminRefundBookingListResponse> {
+  await mockDelay(400);
+  return toAdminRefundListResponse(MOCK_REFUNDING_STUCK, params);
+}
+
+export async function mockRetryRefund(bookingNumber: string): Promise<void> {
+  await mockDelay(500);
+  const idx = MOCK_REFUND_FAILED.findIndex(
+    (b) => b.bookingNumber === bookingNumber,
+  );
+  if (idx === -1) {
+    await mockError("BOOKING_NOT_FOUND", "예매 정보를 찾을 수 없습니다.");
+    return;
+  }
+  // mock: 재시도 성공 시 목록에서 제거
+  MOCK_REFUND_FAILED.splice(idx, 1);
 }

--- a/src/hooks/admin/useAdminRefunds.ts
+++ b/src/hooks/admin/useAdminRefunds.ts
@@ -1,0 +1,51 @@
+// 관리자: 환불 모니터링 hooks — booking-service 실 API (2026-07-18 확인)
+//
+// AdminBookingsPage/AdminRefundsPage가 기존에 쓰던 useAdmin.ts의
+// useAdminBookings/useAdminRefundBooking(전부 mock-only "가상 admin API")과는
+// 별개다. 이 파일은 실제로 존재하는 booking-service admin 엔드포인트
+// (refund-failed / refunding-stuck / refund-retry)만 다룬다.
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getRefundFailedBookingsApi,
+  getRefundingStuckBookingsApi,
+  retryRefundApi,
+} from "@/api/bookings";
+import type { AdminRefundBookingListParams } from "@/types/domain/booking";
+
+const refundKeys = {
+  all: ["admin", "refunds"] as const,
+  failed: (params: AdminRefundBookingListParams) =>
+    ["admin", "refunds", "failed", params] as const,
+  stuck: (params: AdminRefundBookingListParams) =>
+    ["admin", "refunds", "stuck", params] as const,
+};
+
+export function useRefundFailedBookings(params: AdminRefundBookingListParams) {
+  return useQuery({
+    queryKey: refundKeys.failed(params),
+    queryFn: () => getRefundFailedBookingsApi(params),
+    staleTime: 10_000,
+    placeholderData: (prev) => prev,
+  });
+}
+
+export function useRefundingStuckBookings(
+  params: AdminRefundBookingListParams,
+) {
+  return useQuery({
+    queryKey: refundKeys.stuck(params),
+    queryFn: () => getRefundingStuckBookingsApi(params),
+    staleTime: 10_000,
+    placeholderData: (prev) => prev,
+  });
+}
+
+export function useRetryRefund() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: retryRefundApi,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: refundKeys.all });
+    },
+  });
+}

--- a/src/pages/Admin/AdminRefundsPage.tsx
+++ b/src/pages/Admin/AdminRefundsPage.tsx
@@ -83,7 +83,9 @@ export default function AdminRefundsPage() {
           <p className="text-3xl font-bold mb-1" style={{ color: "#FB2C36" }}>
             {failed.data?.items.length ?? 0}
           </p>
-          <p className="text-xs text-admin-text-secondary">환불 처리 실패</p>
+          <p className="text-xs text-admin-text-secondary">
+            환불 처리 실패 (현재 페이지)
+          </p>
         </div>
 
         <div className="bg-admin-card border border-admin-border rounded-xl p-6">
@@ -104,7 +106,9 @@ export default function AdminRefundsPage() {
           <p className="text-3xl font-bold mb-1" style={{ color: "#F59E0B" }}>
             {stuck.data?.items.length ?? 0}
           </p>
-          <p className="text-xs text-admin-text-secondary">환불 지연(멈춤)</p>
+          <p className="text-xs text-admin-text-secondary">
+            환불 지연(멈춤) (현재 페이지)
+          </p>
         </div>
       </div>
 
@@ -112,6 +116,8 @@ export default function AdminRefundsPage() {
         title="환불 처리 실패"
         subtitle="환불 요청 자체가 실패해 재시도가 필요한 예매입니다"
         isLoading={failed.isLoading}
+        isError={failed.isError}
+        onReload={() => void failed.refetch()}
         items={failed.data?.items ?? []}
         dateColumnLabel="실패 시각"
         dateAccessor={(item) => item.refundFailedAt}
@@ -126,6 +132,8 @@ export default function AdminRefundsPage() {
         title="환불 지연 (REFUNDING 멈춤)"
         subtitle="환불 진행 중 상태(REFUNDING)로 오래 멈춰있는 예매입니다"
         isLoading={stuck.isLoading}
+        isError={stuck.isError}
+        onReload={() => void stuck.refetch()}
         items={stuck.data?.items ?? []}
         dateColumnLabel="최종 업데이트"
         dateAccessor={(item) => item.updatedAt}
@@ -143,6 +151,8 @@ function RefundTable({
   title,
   subtitle,
   isLoading,
+  isError,
+  onReload,
   items,
   dateColumnLabel,
   dateAccessor,
@@ -155,6 +165,8 @@ function RefundTable({
   title: string;
   subtitle: string;
   isLoading: boolean;
+  isError: boolean;
+  onReload: () => void;
   items: AdminRefundBookingListItem[];
   dateColumnLabel: string;
   dateAccessor: (item: AdminRefundBookingListItem) => string | null;
@@ -175,6 +187,20 @@ function RefundTable({
       {isLoading ? (
         <div className="text-center py-12 text-admin-text-secondary">
           불러오는 중...
+        </div>
+      ) : isError ? (
+        <div className="text-center py-12 space-y-3">
+          <p className="text-admin-text-secondary">
+            목록을 불러오지 못했습니다.
+          </p>
+          <button
+            type="button"
+            onClick={onReload}
+            className="px-4 py-2 rounded-md text-xs font-bold text-white inline-flex items-center gap-1"
+            style={{ backgroundColor: "#2563EB" }}
+          >
+            <RotateCcw size={12} /> 다시 시도
+          </button>
         </div>
       ) : items.length === 0 ? (
         <div className="text-center py-12 text-admin-text-secondary">

--- a/src/pages/Admin/AdminRefundsPage.tsx
+++ b/src/pages/Admin/AdminRefundsPage.tsx
@@ -1,32 +1,57 @@
+// 환불 모니터링 — booking-service 실 API (2026-07-18 swagger-ui 실측으로 확인)
+//
+// ⚠️ 이전에는 useAdminBookings({status:"CANCELED"}) mock 데이터를 재활용해
+// "환불 내역"을 흉내내고 있었음. 실제 백엔드에는 그런 범용 "취소 예매 목록"
+// 환불 API가 없고, 대신 다음 2개의 구체적인 모니터링 엔드포인트만 존재:
+//   - GET /booking/admin/bookings/refund-failed    (환불 처리 자체가 실패한 건)
+//   - GET /booking/admin/bookings/refunding-stuck  (REFUNDING 상태로 오래 멈춰있는 건)
+//   - POST /booking/admin/{bookingNumber}/refund-retry (재시도)
+//
+// ⚠️ 응답에 사용자 이름/이메일이 없음 (userId만 존재, 조회 가능한 공개 API 없음).
+// 공연명/좌석번호는 performance/seat 서비스에서 aggregation (api/bookings.ts).
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { RotateCcw, CheckCircle, ArrowLeft } from "lucide-react";
-import { useAdminBookings, useAdminBookingStats } from "@/hooks/admin/useAdmin";
+import { AlertTriangle, Clock3, RotateCcw, ArrowLeft } from "lucide-react";
+import { toast } from "react-toastify";
+import {
+  useRefundFailedBookings,
+  useRefundingStuckBookings,
+  useRetryRefund,
+} from "@/hooks/admin/useAdminRefunds";
+import type { AdminRefundBookingListItem } from "@/types/domain/booking";
+
+const PAGE_SIZE = 10;
 
 export default function AdminRefundsPage() {
   const navigate = useNavigate();
-  const [page] = useState(0);
+  const [failedPage, setFailedPage] = useState(0);
+  const [stuckPage, setStuckPage] = useState(0);
 
-  const { data, isLoading } = useAdminBookings({
-    page,
-    size: 10,
-    status: "CANCELED",
-  });
-  const { data: stats } = useAdminBookingStats();
+  const failed = useRefundFailedBookings({ page: failedPage, size: PAGE_SIZE });
+  const stuck = useRefundingStuckBookings({ page: stuckPage, size: PAGE_SIZE });
+  const retryMutation = useRetryRefund();
 
-  const totalRefunds = stats?.cancelledBookings ?? 0;
-  const completedRefunds = Math.floor(totalRefunds * 0.66);
+  async function handleRetry(bookingNumber: string) {
+    try {
+      await retryMutation.mutateAsync(bookingNumber);
+      toast.success(`${bookingNumber} 환불 재시도를 요청했습니다.`);
+    } catch (error: unknown) {
+      const err =
+        error instanceof Error ? error : new Error("재시도 요청에 실패했습니다.");
+      toast.error(err.message);
+    }
+  }
 
   return (
     <div className="p-8 space-y-6">
       <div className="flex items-start justify-between">
         <div>
           <span className="text-[10px] font-bold tracking-wider bg-admin-border px-2 py-1 rounded">
-            REFUND MANAGEMENT
+            REFUND MONITORING
           </span>
-          <h1 className="text-3xl font-bold mt-2">환불 내역 관리</h1>
+          <h1 className="text-3xl font-bold mt-2">환불 모니터링</h1>
           <p className="text-sm text-admin-text-secondary mt-1">
-            환불 내역을 조회하고 관리합니다
+            환불 처리가 실패했거나 오래 지연된 예매를 조회하고 재시도합니다
           </p>
         </div>
         <button
@@ -46,123 +71,190 @@ export default function AdminRefundsPage() {
               className="w-10 h-10 rounded flex items-center justify-center"
               style={{ backgroundColor: "#FB2C36" }}
             >
-              <RotateCcw size={20} className="text-white" />
+              <AlertTriangle size={20} className="text-white" />
             </div>
             <span
               className="px-2 py-0.5 rounded text-[10px] font-bold tracking-wider text-white"
               style={{ backgroundColor: "#FB2C36" }}
             >
-              TOTAL
+              FAILED
             </span>
           </div>
           <p className="text-3xl font-bold mb-1" style={{ color: "#FB2C36" }}>
-            {totalRefunds}
+            {failed.data?.items.length ?? 0}
           </p>
-          <p className="text-xs text-admin-text-secondary">전체 환불</p>
+          <p className="text-xs text-admin-text-secondary">환불 처리 실패</p>
         </div>
 
         <div className="bg-admin-card border border-admin-border rounded-xl p-6">
           <div className="flex items-start justify-between mb-4">
             <div
               className="w-10 h-10 rounded flex items-center justify-center"
-              style={{ backgroundColor: "#00C950" }}
+              style={{ backgroundColor: "#F59E0B" }}
             >
-              <CheckCircle size={20} className="text-white" />
+              <Clock3 size={20} className="text-white" />
             </div>
             <span
               className="px-2 py-0.5 rounded text-[10px] font-bold tracking-wider text-white"
-              style={{ backgroundColor: "#00C950" }}
+              style={{ backgroundColor: "#F59E0B" }}
             >
-              COMPLETED
+              STUCK
             </span>
           </div>
-          <p className="text-3xl font-bold mb-1" style={{ color: "#00C950" }}>
-            {completedRefunds}
+          <p className="text-3xl font-bold mb-1" style={{ color: "#F59E0B" }}>
+            {stuck.data?.items.length ?? 0}
           </p>
-          <p className="text-xs text-admin-text-secondary">완료된 환불</p>
+          <p className="text-xs text-admin-text-secondary">환불 지연(멈춤)</p>
         </div>
       </div>
 
-      {/* 환불 테이블 */}
-      <div className="bg-white border-2 border-[#D0D0D0] rounded-xl p-6">
-        <span className="text-[10px] font-bold tracking-wider bg-admin-border px-2 py-0.5 rounded inline-block mb-2">
-          ORDERS LIST
-        </span>
-        <h3 className="text-base font-bold mb-4 text-gray-900">
-          {data
-            ? `${data.pagination.totalElements}개의 예매 (${data.items.length}개 중)`
-            : "불러오는 중..."}
-        </h3>
+      <RefundTable
+        title="환불 처리 실패"
+        subtitle="환불 요청 자체가 실패해 재시도가 필요한 예매입니다"
+        isLoading={failed.isLoading}
+        items={failed.data?.items ?? []}
+        dateColumnLabel="실패 시각"
+        dateAccessor={(item) => item.refundFailedAt}
+        onRetry={handleRetry}
+        retryPending={retryMutation.isPending}
+        page={failedPage}
+        hasNext={failed.data?.hasNext ?? false}
+        onPageChange={setFailedPage}
+      />
 
-        {isLoading ? (
-          <div className="text-center py-12 text-admin-text-secondary">
-            불러오는 중...
-          </div>
-        ) : !data || data.items.length === 0 ? (
-          <div className="text-center py-12 text-admin-text-secondary">
-            환불 내역이 없습니다.
-          </div>
-        ) : (
+      <RefundTable
+        title="환불 지연 (REFUNDING 멈춤)"
+        subtitle="환불 진행 중 상태(REFUNDING)로 오래 멈춰있는 예매입니다"
+        isLoading={stuck.isLoading}
+        items={stuck.data?.items ?? []}
+        dateColumnLabel="최종 업데이트"
+        dateAccessor={(item) => item.updatedAt}
+        onRetry={handleRetry}
+        retryPending={retryMutation.isPending}
+        page={stuckPage}
+        hasNext={stuck.data?.hasNext ?? false}
+        onPageChange={setStuckPage}
+      />
+    </div>
+  );
+}
+
+function RefundTable({
+  title,
+  subtitle,
+  isLoading,
+  items,
+  dateColumnLabel,
+  dateAccessor,
+  onRetry,
+  retryPending,
+  page,
+  hasNext,
+  onPageChange,
+}: {
+  title: string;
+  subtitle: string;
+  isLoading: boolean;
+  items: AdminRefundBookingListItem[];
+  dateColumnLabel: string;
+  dateAccessor: (item: AdminRefundBookingListItem) => string | null;
+  onRetry: (bookingNumber: string) => void;
+  retryPending: boolean;
+  page: number;
+  hasNext: boolean;
+  onPageChange: (page: number) => void;
+}) {
+  return (
+    <div className="bg-white border-2 border-[#D0D0D0] rounded-xl p-6">
+      <span className="text-[10px] font-bold tracking-wider bg-admin-border px-2 py-0.5 rounded inline-block mb-2">
+        {title}
+      </span>
+      <h3 className="text-base font-bold text-gray-900">{title}</h3>
+      <p className="text-xs text-admin-text-secondary mb-4">{subtitle}</p>
+
+      {isLoading ? (
+        <div className="text-center py-12 text-admin-text-secondary">
+          불러오는 중...
+        </div>
+      ) : items.length === 0 ? (
+        <div className="text-center py-12 text-admin-text-secondary">
+          해당하는 예매가 없습니다.
+        </div>
+      ) : (
+        <>
           <table className="w-full text-sm text-left admin-table">
             <thead className="border-b border-admin-border">
               <tr className="text-xs text-admin-text-secondary">
                 <th className="py-3 px-3 text-left">예매번호</th>
                 <th className="py-3 px-3 text-left">공연명</th>
-                <th className="py-3 px-3 text-left">공연날짜</th>
-                <th className="py-3 px-3 text-left">예매일시</th>
-                <th className="py-3 px-3 text-left">예매자</th>
-                <th className="py-3 px-3 text-left">금액</th>
+                <th className="py-3 px-3 text-left">좌석</th>
+                <th className="py-3 px-3 text-left">사용자ID</th>
                 <th className="py-3 px-3 text-left">상태</th>
-                <th className="py-3 px-3 text-left">상세</th>
+                <th className="py-3 px-3 text-left">{dateColumnLabel}</th>
+                <th className="py-3 px-3 text-left">재시도</th>
               </tr>
             </thead>
             <tbody>
-              {data.items.map((b, idx) => {
-                const isCompleted = idx % 2 === 0;
-                return (
-                  <tr
-                    key={b.bookingNumber}
-                    className="border-b border-admin-border/50 hover:bg-admin-border/30"
-                  >
-                    <td className="py-3 px-3 font-mono text-xs text-blue-400">
-                      {b.bookingNumber}
-                    </td>
-                    <td className="py-3 px-3 font-bold">{b.concertTitle}</td>
-                    <td className="py-3 px-3 text-xs text-admin-text-secondary">
-                      {b.concertDate}
-                    </td>
-                    <td className="py-3 px-3 text-xs text-admin-text-secondary">
-                      {new Date(b.bookedAt).toLocaleString("ko-KR")}
-                    </td>
-                    <td className="py-3 px-3">{b.userName}</td>
-                    <td className="py-3 px-3 font-bold">
-                      ₩{b.totalAmount.toLocaleString()}
-                    </td>
-                    <td className="py-3 px-3">
-                      <span
-                        className="px-3 py-1 rounded-md text-xs font-bold text-white"
-                        style={{ backgroundColor: "#FB2C36" }}
-                      >
-                        신청
-                      </span>
-                    </td>
-                    <td className="py-3 px-3">
-                      <span
-                        className="px-3 py-1 rounded-md text-xs font-bold text-white"
-                        style={{
-                          backgroundColor: isCompleted ? "#00C950" : "#9CA3AF",
-                        }}
-                      >
-                        {isCompleted ? "완료" : "대기"}
-                      </span>
-                    </td>
-                  </tr>
-                );
-              })}
+              {items.map((b) => (
+                <tr
+                  key={b.bookingNumber}
+                  className="border-b border-admin-border/50 hover:bg-admin-border/30"
+                >
+                  <td className="py-3 px-3 font-mono text-xs text-blue-400">
+                    {b.bookingNumber}
+                  </td>
+                  <td className="py-3 px-3 font-bold">{b.performanceTitle}</td>
+                  <td className="py-3 px-3">{b.seatNumber}</td>
+                  <td className="py-3 px-3 text-xs text-admin-text-secondary">
+                    #{b.userId}
+                  </td>
+                  <td className="py-3 px-3">
+                    <span className="px-3 py-1 rounded-md text-xs font-bold text-white bg-gray-500">
+                      {b.status}
+                    </span>
+                  </td>
+                  <td className="py-3 px-3 text-xs text-admin-text-secondary">
+                    {(() => {
+                      const dt = dateAccessor(b);
+                      return dt ? new Date(dt).toLocaleString("ko-KR") : "-";
+                    })()}
+                  </td>
+                  <td className="py-3 px-3">
+                    <button
+                      type="button"
+                      onClick={() => onRetry(b.bookingNumber)}
+                      disabled={retryPending}
+                      className="px-3 py-1 rounded-md text-xs font-bold text-white flex items-center gap-1"
+                      style={{ backgroundColor: "#2563EB" }}
+                    >
+                      <RotateCcw size={12} /> 재시도
+                    </button>
+                  </td>
+                </tr>
+              ))}
             </tbody>
           </table>
-        )}
-      </div>
+
+          <div className="flex justify-end gap-2 mt-4">
+            <button
+              type="button"
+              onClick={() => onPageChange(Math.max(0, page - 1))}
+              disabled={page === 0}
+              className="px-3 py-1.5 rounded-md text-xs bg-admin-border disabled:opacity-40"
+            >
+              이전
+            </button>
+            <button
+              type="button"
+              onClick={() => onPageChange(page + 1)}
+              disabled={!hasNext}
+              className="px-3 py-1.5 rounded-md text-xs bg-admin-border disabled:opacity-40"
+            >
+              다음
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/types/domain/booking.ts
+++ b/src/types/domain/booking.ts
@@ -167,3 +167,43 @@ export interface MyBookingsResponse {
 export interface MyBookingCountResponse {
   count: number;
 }
+
+// ── 관리자: 환불 모니터링 (백엔드 확정, 2026-07-18 swagger-ui 실측) ────
+// 백엔드 endpoint:
+//   GET  /api/v1/booking/admin/bookings/refund-failed    (환불 처리 자체가 실패한 건)
+//   GET  /api/v1/booking/admin/bookings/refunding-stuck  (REFUNDING 상태로 오래 멈춰있는 건)
+//   POST /api/v1/booking/admin/{bookingNumber}/refund-retry (재시도)
+
+// 응답은 BookingSummaryResponse와 동일 shape + userId/refundFailedAt/updatedAt.
+// ⚠️ 사용자 이름/이메일/공연명/좌석번호는 이 응답에 없음
+// userId만 있고
+// 프론트에서 조회 가능한 "userId → 사용자 정보" API가 없어(내부 전용 API만 존재)
+// 사용자 식별 정보는 표시 불가.
+// 공연명/좌석번호는 performance/seat 서비스에서 aggregation.
+export interface AdminRefundBookingItem {
+  bookingId: number;
+  bookingNumber: string;
+  userId: number;
+  performanceId: number;
+  seatId: number;
+  status: BookingStatus;
+  confirmedAt: string | null;
+  refundFailedAt: string | null;
+  updatedAt: string;
+}
+
+/** AdminRefundBookingItem + performance/seat aggregation (프론트 표시용) */
+export interface AdminRefundBookingListItem extends AdminRefundBookingItem {
+  performanceTitle: string;
+  seatNumber: string;
+}
+
+export interface AdminRefundBookingListParams {
+  page?: number;
+  size?: number;
+}
+
+export interface AdminRefundBookingListResponse {
+  items: AdminRefundBookingListItem[];
+  hasNext: boolean;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #135

---

## 📌 주요 변경 사항

- 관리자 환불 처리 실패/지연 건 모니터링 실 API 연동
- 환불 목록 조회 실패 시 에러 + 재시도 UI 추가
- `seatNumbers` 집계 로직 try/catch 방어 (일부 실패해도 전체 화면 깨지지 않음)
- 통계에 "현재 페이지" 표시 추가
***

## 🛠 상세 구현 내용

- `src/api/bookings.ts`: `fetchSeatNumbers` 집계 부분 try/catch 처리
- `AdminRefundsPage`: 에러 상태 UI + 재시도 버튼
***

## ✅ 테스트

### 테스트 방법

- 관리자 환불 목록 페이지 진입 → 정상 조회 확인
- API 실패 유도 → 에러 UI + 재시도 동작 확인
- `seatNumbers` 일부 실패 시 나머지 목록은 정상 렌더되는지 확인

### 테스트 결과

- 로컬 수동 테스트, `tsc --noEmit` 통과

### 📸 스크린샷

---

## 👀 리뷰 요청 사항

- 재시도 UX(버튼 위치/문구)가 적절한지
***

## ⚠️ 배포 시 주의사항

- booking-service 환불 관련 API 실 연동 확인
- `feature/124-125`(#146) 이후 머지 권장
